### PR TITLE
Tests: Use PHPStan 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
       DB_PASS: root
       DB_HOST: localhost
       INSTALL_PLUGINS: "custom-order-numbers-for-woocommerce woocommerce woocommerce-gateway-stripe" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS_URLS: "http://cktestplugins.wpengine.com/wp-content/uploads/2024/11/disable-doing-it-wrong-notices.zip" # URLs to specific third party Plugins
       STRIPE_TEST_PUBLISHABLE_KEY: ${{ secrets.STRIPE_TEST_PUBLISHABLE_KEY }} # Stripe Test API Publishable Key, stored in the repository's Settings > Secrets
       STRIPE_TEST_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }} # Stripe Test API Secret Key, stored in the repository's Settings > Secrets
       CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
@@ -125,6 +126,11 @@ jobs:
       - name: Install Free Third Party WordPress Plugins
         working-directory: ${{ env.ROOT_DIR }}
         run: wp-cli plugin install ${{ env.INSTALL_PLUGINS }} --activate
+
+      # env.INSTALL_PLUGINS_URLS is a list of Plugin URLs, space separated, to install specific versions ot third party Plugins.
+      - name: Install Free Third Party WordPress Specific Version Plugins
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli plugin install ${{ env.INSTALL_PLUGINS_URLS }}
 
       # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
       # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
         "codeception/util-universalframework": "^1.0",
         "php-webdriver/webdriver": "^1.0",
         "wp-coding-standards/wpcs": "^3.0.0",
-        "phpstan/phpstan": "^1.7",
-        "szepeviktor/phpstan-wordpress": "^1.0",
-        "wp-cli/wp-cli-bundle": "2.9.0"
+        "phpstan/phpstan": "^1.0 || ^2.0",
+        "szepeviktor/phpstan-wordpress": "^1.0 || ^2.0",
+        "wp-cli/wp-cli-bundle": "2.11"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -276,9 +276,6 @@ class CKWC_Integration extends WC_Integration {
 		global $wp_filesystem;
 
 		// Bail if no configuration file was supplied.
-		if ( ! is_array( $_FILES ) ) {
-			return;
-		}
 		if ( ! array_key_exists( 'woocommerce_ckwc_import', $_FILES ) ) {
 			return;
 		}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,6 +21,10 @@ parameters:
     scanDirectories:
         - /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress/wp-content/plugins
 
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress/wp-config.php
+
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels
     level: 5

--- a/phpstan.neon.example
+++ b/phpstan.neon.example
@@ -1,4 +1,4 @@
-# PHPStan configuration for local static analysis.
+# PHPStan configuration for GitHub Actions.
 
 # Include PHPStan for WordPress configuration.
 includes:
@@ -19,7 +19,11 @@ parameters:
 
     # Location of WordPress Plugins for PHPStan to scan, building symbols.
     scanDirectories:
-        - /Users/tim/Local Sites/convertkit-github/app/public/wp-content/plugins
+        - /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress/wp-content/plugins
+
+    # Location of constants for PHPStan to scan, building symbols.
+    scanFiles:
+        - /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress/wp-config.php
 
     # Should not need to edit anything below here
     # Rule Level: https://phpstan.org/user-guide/rule-levels

--- a/tests/_support/Helper/Acceptance/Plugin.php
+++ b/tests/_support/Helper/Acceptance/Plugin.php
@@ -47,6 +47,9 @@ class Plugin extends \Codeception\Module
 	 */
 	public function activateWooCommerceAndConvertKitPlugins($I)
 	{
+		// Activate Disable _load_textdomain notice.
+		$I->activateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
+
 		// Activate ConvertKit Plugin.
 		$I->activateConvertKitPlugin($I);
 
@@ -78,6 +81,8 @@ class Plugin extends \Codeception\Module
 		// Deactivate WooCommerce Stripe Gateway before WooCommerce, to prevent WooCommerce throwing a fatal error.
 		$I->deactivateThirdPartyPlugin($I, 'woocommerce-gateway-stripe');
 		$I->deactivateThirdPartyPlugin($I, 'woocommerce');
+
+		$I->deactivateThirdPartyPlugin($I, 'disable-_load_textdomain_just_in_time-doing_it_wrong-notice');
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Runs static analysis using the latest [2.0](https://github.com/phpstan/phpstan/blob/2.0.x/UPGRADING.md) version of PHPStan when tests are performed on PHP 7.4 and higher, which is the minimum supported version.

PHPStan 1.x will run on tests using PHP < 7.4.

Includes [this PR](https://github.com/Kit/convertkit-wordpress/pull/747) fix for `_load_textdomain_just_in_time` errors caused by third party Plugins.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)