### PR TITLE
Form Subscribe: Add `referrer` support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-       "convertkit/convertkit-wordpress-libraries": "2.0.5"
+       "convertkit/convertkit-wordpress-libraries": "2.0.6"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -268,7 +268,7 @@ class CKWC_Order {
 				}
 
 				// Add subscriber to form.
-				$result = $this->api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
+				$result = $this->api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'], home_url() );
 				break;
 
 			case 'tag':

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -263,7 +263,7 @@ class ConvertKitAPI extends \Codeception\Module
 	public function apiCustomFieldDataIsValid($I, $subscriber, $excludeNameFromAddress = false)
 	{
 		$I->assertEquals($subscriber['fields']['last_name'], 'Last');
-		$I->assertEquals($subscriber['fields']['phone_number'], '123-123-1234');
+		$I->assertEquals($subscriber['fields']['phone_number'], '1231231234');
 		$I->assertEquals($subscriber['fields']['billing_address'], ( $excludeNameFromAddress ? 'Address Line 1, City, CA 12345' : 'First Last, Address Line 1, City, CA 12345' ));
 		$I->assertEquals($subscriber['fields']['payment_method'], 'cod');
 		$I->assertEquals($subscriber['fields']['notes'], 'Notes');

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -115,7 +115,6 @@ class ConvertKitAPI extends \Codeception\Module
 			[
 				// Check all subscriber states.
 				'status'   => 'all',
-				'per_page' => 20,
 			]
 		);
 

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -97,6 +97,47 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
+	 * Check the given subscriber ID has been assigned to the given form ID.
+	 *
+	 * @since   1.9.1
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $subscriberID  Subscriber ID.
+	 * @param   int              $formID        Form ID.
+	 * @param   string           $referrer      Referrer.
+	 */
+	public function apiCheckSubscriberHasForm($I, $subscriberID, $formID, $referrer = false)
+	{
+		// Run request.
+		$results = $this->apiRequest(
+			'forms/' . $formID . '/subscribers',
+			'GET',
+			[
+				// Check all subscriber states.
+				'status'   => 'all',
+				'per_page' => 20,
+			]
+		);
+
+		// Iterate through subscribers.
+		$subscriberHasForm = false;
+		foreach ($results['subscribers'] as $subscriber) {
+			if ($subscriber['id'] === $subscriberID) {
+				$subscriberHasForm = true;
+				break;
+			}
+		}
+
+		// Assert if the subscriber has the form.
+		$this->assertTrue($subscriberHasForm);
+
+		// If a referrer is specified, assert it matches the subscriber's referrer now.
+		if ($referrer) {
+			$I->assertEquals($subscriber['referrer'], $referrer);
+		}
+	}
+
+	/**
 	 * Check the given order ID exists as a purchase on ConvertKit.
 	 *
 	 * @param   AcceptanceTester $I             AcceptanceTester.

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -114,7 +114,7 @@ class ConvertKitAPI extends \Codeception\Module
 			'GET',
 			[
 				// Check all subscriber states.
-				'status'   => 'all',
+				'status' => 'all',
 			]
 		);
 

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -77,10 +77,7 @@ class WooCommerce extends \Codeception\Module
 	 */
 	public function setupWooCommerceHPOS($I)
 	{
-		$I->amOnAdminPage('admin.php?page=wc-settings&tab=advanced&section=features');
-		$I->waitForElementVisible('input[name="woocommerce_custom_orders_table_enabled"]');
-		$I->selectOption('input[name="woocommerce_custom_orders_table_enabled"]', 'yes');
-		$I->click('Save changes');
+		$I->haveOptionInDatabase('woocommerce_custom_orders_table_enabled', 'yes');
 	}
 
 	/**

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -656,7 +656,7 @@ class WooCommerce extends \Codeception\Module
 				$I->fillField('#billing_address_1', 'Address Line 1');
 				$I->fillField('#billing_city', 'City');
 				$I->fillField('#billing_postcode', '12345');
-				$I->fillField('#billing_phone', '123-123-1234');
+				$I->fillField('#billing_phone', '1231231234');
 				$I->fillField('#billing_email', $emailAddress);
 				$I->fillField('#order_comments', 'Notes');
 				break;
@@ -668,7 +668,7 @@ class WooCommerce extends \Codeception\Module
 				$I->fillField('#billing-address_1', 'Address Line 1');
 				$I->fillField('#billing-city', 'City');
 				$I->fillField('#billing-postcode', '12345');
-				$I->fillField('#billing-phone', '123-123-1234');
+				$I->fillField('#billing-phone', '1231231234');
 				$I->fillField('#email', $emailAddress);
 				$I->checkOption('.wc-block-checkout__add-note input.wc-block-components-checkbox__input');
 				$I->fillField('.wc-block-components-textarea', 'Notes');

--- a/tests/acceptance/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
@@ -62,6 +62,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		// in the integration's settings.
 		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 
@@ -125,6 +133,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		// Confirm that the email address was added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
 		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
@@ -166,6 +182,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
 
@@ -204,6 +228,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.

--- a/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -62,6 +62,14 @@ class SubscribeOnOrderCompletedEventCest
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 	}
@@ -128,6 +136,14 @@ class SubscribeOnOrderCompletedEventCest
 
 		// Confirm that the email address was added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -56,6 +56,14 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 	}
@@ -111,6 +119,14 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Confirm that the email address was added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 	}
@@ -143,6 +159,14 @@ class SubscribeOnOrderPendingPaymentEventCest
 
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -181,6 +205,14 @@ class SubscribeOnOrderPendingPaymentEventCest
 
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -61,6 +61,14 @@ class SubscribeOnOrderProcessingEventCest
 		// in the integration's settings.
 		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 
@@ -126,6 +134,14 @@ class SubscribeOnOrderProcessingEventCest
 		// in the integration's settings.
 		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 
@@ -165,6 +181,14 @@ class SubscribeOnOrderProcessingEventCest
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 	}
@@ -203,6 +227,14 @@ class SubscribeOnOrderProcessingEventCest
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
 		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);


### PR DESCRIPTION
## Summary

Specifies the WordPress site URL as the `referrer` parameter, when the Plugin is configured to subscribe the email address to a Kit Form.

![Screenshot 2025-01-09 at 10 50 50](https://github.com/user-attachments/assets/1a46c2fa-2680-4553-b40b-ef9065aef713)

## Testing

- Updated opt in form tests to assert subscriber is assigned the form and has the expected referrer.

## Checklist

* [x] I have [written a test](TESTING.md#writing-a-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] The code passes when [running PHPStan](TESTING.md#run-phpstan)
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)