### PR TITLE
Register Opt-In Checkbox using `woocommerce_register_additional_checkout_field`

### DIFF
--- a/.github/workflows/test-backward-compat.yml
+++ b/.github/workflows/test-backward-compat.yml
@@ -1,0 +1,251 @@
+name: Run Tests
+
+# When to run tests.
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+  push:
+    branches:
+      - main
+
+jobs:
+  tests:
+    # Name.
+    name: ${{ matrix.test-groups }} / WordPress ${{ matrix.wp-versions }} / PHP ${{ matrix.php-versions }}
+
+    # Virtual Environment to use.
+    # @see: https://github.com/actions/virtual-environments
+    runs-on: ubuntu-20.04
+
+    # Environment Variables.
+    # Accessible by using ${{ env.NAME }}
+    # Use ${{ secrets.NAME }} to include any GitHub Secrets in ${{ env.NAME }}
+    # The base folder will always be /home/runner/work/github-repo-name/github-repo-name
+    env:
+      ROOT_DIR: /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress
+      PLUGIN_DIR: /home/runner/work/convertkit-woocommerce/convertkit-woocommerce/wordpress/wp-content/plugins/convertkit-woocommerce
+      DB_NAME: test
+      DB_USER: root
+      DB_PASS: root
+      DB_HOST: localhost
+      INSTALL_PLUGINS: "custom-order-numbers-for-woocommerce woocommerce-gateway-stripe" # Don't include this repository's Plugin here.
+      INSTALL_PLUGINS_URLS: "http://cktestplugins.wpengine.com/wp-content/uploads/2024/11/disable-doing-it-wrong-notices.zip https://downloads.wordpress.org/plugin/woocommerce.8.4.0.zip" # URLs to specific third party Plugins
+      STRIPE_TEST_PUBLISHABLE_KEY: ${{ secrets.STRIPE_TEST_PUBLISHABLE_KEY }} # Stripe Test API Publishable Key, stored in the repository's Settings > Secrets
+      STRIPE_TEST_SECRET_KEY: ${{ secrets.STRIPE_TEST_SECRET_KEY }} # Stripe Test API Secret Key, stored in the repository's Settings > Secrets
+      CONVERTKIT_API_KEY: ${{ secrets.CONVERTKIT_API_KEY }} # ConvertKit API Key, stored in the repository's Settings > Secrets
+      CONVERTKIT_API_SECRET: ${{ secrets.CONVERTKIT_API_SECRET }} # ConvertKit API Secret, stored in the repository's Settings > Secrets
+      CONVERTKIT_API_KEY_NO_DATA: ${{ secrets.CONVERTKIT_API_KEY_NO_DATA }} # ConvertKit API Key for ConvertKit account with no data, stored in the repository's Settings > Secrets
+      CONVERTKIT_API_SECRET_NO_DATA: ${{ secrets.CONVERTKIT_API_SECRET_NO_DATA }} # ConvertKit API Secret for ConvertKit account with no data, stored in the repository's Settings > Secrets
+      CONVERTKIT_OAUTH_ACCESS_TOKEN: ${{ secrets.CONVERTKIT_OAUTH_ACCESS_TOKEN }}
+      CONVERTKIT_OAUTH_REFRESH_TOKEN: ${{ secrets.CONVERTKIT_OAUTH_REFRESH_TOKEN }}
+      CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA: ${{ secrets.CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
+      CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA: ${{ secrets.CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA }}
+      CONVERTKIT_OAUTH_CLIENT_ID: ${{ secrets.CONVERTKIT_OAUTH_CLIENT_ID }}
+      CONVERTKIT_OAUTH_REDIRECT_URI: ${{ secrets.CONVERTKIT_OAUTH_REDIRECT_URI }}
+      KIT_OAUTH_REDIRECT_URI: ${{ secrets.KIT_OAUTH_REDIRECT_URI }}
+
+    # Defines the WordPress and PHP Versions matrix to run tests on
+    # WooCommerce 5.9.0 requires WordPress 5.6 or greater, so we do not test on earlier versions
+    # If testing older WordPress versions, ensure they are e.g. 5.7.4, 5.6.6 that have the X3 SSL fix: https://core.trac.wordpress.org/ticket/54207
+    # For PHP, make sure that an nginx configuration file exists for the required PHP version in this repository at tests/nginx/php-x.x.conf
+    strategy:
+      fail-fast: false
+      matrix:
+        wp-versions: [ 'latest' ] #[ '6.1.1', 'latest' ]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3' ] #[ '7.4', '8.0', '8.1' ]
+        
+        # Folder names within the 'tests' folder to run tests in parallel.
+        test-groups: [
+          'acceptance/backward-compat'
+        ]
+
+    # Steps to install, configure and run tests
+    steps:
+      - name: Define Test Group Name
+        id: test-group
+        uses: mad9000/actions-find-and-replace-string@5
+        with:
+          source: ${{ matrix.test-groups }}
+          find: '/'        
+          replace: '-'
+          replaceAll: true
+
+      - name: Start MySQL
+        run: sudo systemctl start mysql.service
+
+      - name: Create MySQL Database
+        run: |
+          mysql -e 'CREATE DATABASE test;' -u${{ env.DB_USER }} -p${{ env.DB_PASS }}
+          mysql -e 'SHOW DATABASES;' -u${{ env.DB_USER }} -p${{ env.DB_PASS }}
+
+      # WordPress won't be able to connect to the DB if we don't perform this step.
+      - name: Permit MySQL Password Auth for MySQL 8.0
+        run: mysql -e "ALTER USER '${{ env.DB_USER }}'@'${{ env.DB_HOST }}' IDENTIFIED WITH mysql_native_password BY '${{ env.DB_PASS }}';"  -u${{ env.DB_USER }} -p${{ env.DB_PASS }} 
+
+      # Some workflows checkout WordPress from GitHub, but that seems to bring a bunch of uncompiled files with it.
+      # Instead download from wordpress.org stable.
+      - name: Download WordPress
+        run: wget https://wordpress.org/wordpress-${{ matrix.wp-versions }}.tar.gz
+
+      - name: Extract WordPress
+        run: tar xfz wordpress-${{ matrix.wp-versions }}.tar.gz
+
+      # Checkout (copy) this repository's Plugin to this VM.
+      - name: Checkout Plugin
+        uses: actions/checkout@v4
+        with:
+          path: ${{ env.PLUGIN_DIR }}
+
+      # We install WP-CLI, as it provides useful commands to setup and install WordPress through the command line.
+      - name: Install WP-CLI
+        run: |
+          curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+          chmod +x wp-cli.phar
+          sudo mv wp-cli.phar /usr/local/bin/wp-cli
+
+      - name: Setup wp-config.php
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli config create --dbname=${{ env.DB_NAME }} --dbuser=${{ env.DB_USER }} --dbpass=${{ env.DB_PASS }} --dbhost=${{ env.DB_HOST }} --locale=en_DB
+
+      - name: Install WordPress
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli core install --url=127.0.0.1 --title=ConvertKit --admin_user=admin --admin_password=password --admin_email=wordpress@convertkit.local
+
+      # env.INSTALL_PLUGINS is a list of Plugin slugs, space separated e.g. contact-form-7 woocommerce.
+      # We activate the Plugins so that any directories they create are added now, before we later set
+      # directory permissions in this action.
+      # These Plugins won't be active when Codeception's acceptance tests run, as Codeception copies
+      # the tests/_data/dump.sql, which has no active Plugins specified.
+      - name: Install Free Third Party WordPress Plugins
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli plugin install ${{ env.INSTALL_PLUGINS }} --activate
+
+      # env.INSTALL_PLUGINS_URLS is a list of Plugin URLs, space separated, to install specific versions ot third party Plugins.
+      - name: Install Free Third Party WordPress Specific Version Plugins
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli plugin install ${{ env.INSTALL_PLUGINS_URLS }}
+
+      # These should be stored as a separated list of URLs in the repository Settings > Secrets > Repository Secret > CONVERTKIT_PAID_PLUGIN_URLS.
+      # We cannot include the URLs in this file, as they're not Plugins we are permitted to distribute.
+      - name: Install Paid Third Party WordPress Plugins
+        working-directory: ${{ env.ROOT_DIR }}
+        run: wp-cli plugin install ${{ secrets.CONVERTKIT_PAID_PLUGIN_URLS }}
+      
+      # WP_DEBUG = true is required so all PHP errors are output and caught by tests (E_ALL).
+      # WP_DEBUG = false for PHP 8.1+, otherwise E_DEPRECATED is output due to WooCommerce.
+      - name: Enable WP_DEBUG
+        if: ${{ matrix.php-versions != '8.1' && matrix.php-versions != '8.2' && matrix.php-versions != '8.3' }}
+        working-directory: ${{ env.ROOT_DIR }}
+        run: |
+          wp-cli config set WP_DEBUG true --raw
+
+      # FS_METHOD = direct is required for WP_Filesystem to operate without suppressed PHP fopen() errors that trip up tests.
+      - name: Enable FS_METHOD
+        working-directory: ${{ env.ROOT_DIR }}
+        run: |
+          wp-cli config set FS_METHOD direct
+
+      # This step is deliberately after WordPress installation and configuration, as enabling PHP 8.x before using WP-CLI results
+      # in the workflow failing due to incompatibilities between WP-CLI and PHP 8.x.
+      # By installing PHP at this stage, we can still run our tests against e.g. PHP 8.x.
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: xdebug
+
+      # Make sure that an nginx configuration file exists in this repository at tests/nginx/php-x.x.conf.
+      # Refer to an existing .conf file in this repository if you need to create a new one e.g. for a new PHP version.
+      - name: Copy nginx configuration file
+        run: sudo cp ${{ env.PLUGIN_DIR }}/tests/nginx/php-${{ matrix.php-versions }}.conf /etc/nginx/conf.d/php-${{ matrix.php-versions }}.conf
+
+      - name: Test nginx
+        run: sudo nginx -t
+
+      - name: Start nginx
+        run: sudo systemctl start nginx.service
+        
+      - name: Install chromedriver
+        uses: nanasess/setup-chromedriver@master
+
+      - name: Start chromedriver
+        run: |
+          export DISPLAY=:99
+          chromedriver --port=9515 --url-base=/wd/hub &
+          sudo Xvfb -ac :99 -screen 0 1920x1080x24 > /dev/null 2>&1 & # optional
+
+      # Write any secrets, such as API keys, to the .env.dist.testing file now.
+      # Make sure your committed .env.dist.testing file ends with a newline.
+      # The formatting of the contents to include a blank newline is deliberate.
+      - name: Define GitHub Secrets in .env.dist.testing
+        uses: DamianReeves/write-file-action@v1.2
+        with:
+          path: ${{ env.PLUGIN_DIR }}/.env.dist.testing
+          contents: |
+
+            STRIPE_TEST_PUBLISHABLE_KEY=${{ env.STRIPE_TEST_PUBLISHABLE_KEY }}
+            STRIPE_TEST_SECRET_KEY=${{ env.STRIPE_TEST_SECRET_KEY }}
+            CONVERTKIT_API_KEY=${{ env.CONVERTKIT_API_KEY }}
+            CONVERTKIT_API_SECRET=${{ env.CONVERTKIT_API_SECRET }}
+            CONVERTKIT_API_KEY_NO_DATA=${{ env.CONVERTKIT_API_KEY_NO_DATA }}
+            CONVERTKIT_API_SECRET_NO_DATA=${{ env.CONVERTKIT_API_SECRET_NO_DATA }}
+            CONVERTKIT_OAUTH_ACCESS_TOKEN=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN }}
+            CONVERTKIT_OAUTH_REFRESH_TOKEN=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN }}
+            CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_ACCESS_TOKEN_NO_DATA }}
+            CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA=${{ env.CONVERTKIT_OAUTH_REFRESH_TOKEN_NO_DATA }}
+            CONVERTKIT_OAUTH_CLIENT_ID=${{ env.CONVERTKIT_OAUTH_CLIENT_ID }}
+            CONVERTKIT_OAUTH_REDIRECT_URI=${{ env.CONVERTKIT_OAUTH_REDIRECT_URI }}
+            KIT_OAUTH_REDIRECT_URI=${{ env.KIT_OAUTH_REDIRECT_URI }}
+          write-mode: append
+
+      # Installs wp-browser, Codeception, PHP CodeSniffer and anything else needed to run tests.
+      - name: Run Composer
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: composer update
+
+      - name: Build PHP Autoloader
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: composer dump-autoload
+
+      # This ensures the Plugin's log file can be written to.
+      # We don't recursively do this, as it'll prevent Codeception from writing to the /tests/_output directory.
+      - name: Set Permissions for Plugin Directory
+        run: |
+          sudo chmod g+w ${{ env.PLUGIN_DIR }}
+          sudo chown www-data:www-data ${{ env.PLUGIN_DIR }}
+
+      # This ensures WooCommerce log files can be written to.
+      - name: Set Permissions for WooCommerce Logs Directory
+        run: |
+          sudo mkdir ${{ env.ROOT_DIR }}/wp-content/uploads/wc-logs
+          sudo chmod g+w ${{ env.ROOT_DIR }}/wp-content/uploads/wc-logs
+          sudo chown www-data:www-data ${{ env.ROOT_DIR }}/wp-content/uploads/wc-logs
+
+      # Build Codeception Tests.
+      - name: Build Tests
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/codecept build
+
+      # Run Codeception WPUnit Tests on the PHP 7.4 instance before the acceptance/general acceptance tests.
+      # We run these once to avoid hitting API rate limits.
+      - name: Run tests/wpunit
+        if: ${{ matrix.php-versions == '7.4' && matrix.test-groups == 'acceptance/general' }}
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/codecept run tests/wpunit --fail-fast
+
+      # Run Codeception Acceptance Tests.
+      - name: Run tests/${{ matrix.test-groups }}
+        working-directory: ${{ env.PLUGIN_DIR }}
+        run: php vendor/bin/codecept run tests/${{ matrix.test-groups }} --fail-fast
+
+      # Artifacts are data generated by this workflow that we want to access, such as log files, screenshots, HTML output.
+      # The if: failure() directive means that this will run when the workflow fails e.g. if a test fails, which is needed
+      # because we want to see why a test failed.
+      - name: Upload Test Results to Artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ steps.test-group.outputs.value }}-${{ matrix.php-versions }}
+          path: ${{ env.PLUGIN_DIR }}/tests/_output/

--- a/.github/workflows/test-backward-compat.yml
+++ b/.github/workflows/test-backward-compat.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: Run Backward Compat. Tests
 
 # When to run tests.
 on:

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "project",
     "license": "GPLv3",
     "require": {
-       "convertkit/convertkit-wordpress-libraries": "2.0.5"
+       "convertkit/convertkit-wordpress-libraries": "2.0.6"
     },
     "require-dev": {
         "lucatume/wp-browser": "<3.5",

--- a/includes/blocks/opt-in/class-ckwc-opt-in-block-integration.php
+++ b/includes/blocks/opt-in/class-ckwc-opt-in-block-integration.php
@@ -74,9 +74,11 @@ class CKWC_Opt_In_Block_Integration implements IntegrationInterface {
 			),
 
 			// Where to display the block within the WooCommerce Checkout Block.
+			/*
 			'parent'        => array(
 				'woocommerce/checkout-contact-information-block',
 			),
+			*/
 
 			// Attributes.
 			'attributes'    => array(

--- a/includes/blocks/opt-in/class-ckwc-opt-in-block-integration.php
+++ b/includes/blocks/opt-in/class-ckwc-opt-in-block-integration.php
@@ -74,11 +74,9 @@ class CKWC_Opt_In_Block_Integration implements IntegrationInterface {
 			),
 
 			// Where to display the block within the WooCommerce Checkout Block.
-			/*
 			'parent'        => array(
 				'woocommerce/checkout-contact-information-block',
 			),
-			*/
 
 			// Attributes.
 			'attributes'    => array(

--- a/includes/class-ckwc-checkout.php
+++ b/includes/class-ckwc-checkout.php
@@ -72,7 +72,7 @@ class CKWC_Checkout {
 			// No opt in checkbox is displayed; always opt in the customer at checkout.
 
 			// Opt the customer in when using the checkout shortcode.
-			add_action( 'woocommerce_checkout_order_created', array( $this, 'save_opt_in_checkbox' ), 10, 1 );
+			add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'save_opt_in_checkbox' ), 10, 1 );
 
 			// Opt the customer in when using the checkout block.
 			add_action( 'woocommerce_store_api_checkout_update_order_from_request', array( $this, 'save_opt_in_checkbox_block' ), 10, 2 );

--- a/includes/class-ckwc-checkout.php
+++ b/includes/class-ckwc-checkout.php
@@ -66,7 +66,7 @@ class CKWC_Checkout {
 		// 8.9.0 and higher introduces a single `woocommerce_register_additional_checkout_field()` method to register
 		// the opt in field when using the WooCommerce Checkout Block.
 		if ( function_exists( 'woocommerce_register_additional_checkout_field' ) ) {
-			// Store whether the customer should be opted in, in the Order's metadata, when using the Checkout additional field. 
+			// Store whether the customer should be opted in, in the Order's metadata, when using the Checkout additional field.
 			add_action( 'woocommerce_set_additional_field_value', array( $this, 'save_opt_in_checkbox_additional_field' ), 10, 4 );
 		} else {
 			// Store whether the customer should be opted in, in the Order's metadata, when using the Checkout block.
@@ -170,10 +170,10 @@ class CKWC_Checkout {
 
 		woocommerce_register_additional_checkout_field(
 			array(
-				'id'            => 'ckwc/opt-in',
-				'label'         => $this->integration->get_option( 'opt_in_label' ),
-				'type'			=> 'checkbox',
-				'attributes' 	=> array(
+				'id'                         => 'ckwc/opt-in',
+				'label'                      => $this->integration->get_option( 'opt_in_label' ),
+				'type'                       => 'checkbox',
+				'attributes'                 => array(
 					// This is deliberate; WooCommerce won't support a `checked` attribute for checkboxes.
 					// Frontend JS will check for data-checked and convert it to the `checked` attribute.
 					'data-checked' => $this->integration->get_option( 'opt_in_status' ),
@@ -182,7 +182,7 @@ class CKWC_Checkout {
 
 				// location supports contact, address or order. We store 'billing' to mean address in the Plugin settings.
 				// @see https://github.com/woocommerce/woocommerce/blob/trunk/docs/cart-and-checkout-blocks/additional-checkout-fields.md.
-				'location'      => ( $this->integration->get_option( 'opt_in_location' ) === 'billing' ? 'address' : $this->integration->get_option( 'opt_in_location' ) ),
+				'location'                   => ( $this->integration->get_option( 'opt_in_location' ) === 'billing' ? 'address' : $this->integration->get_option( 'opt_in_location' ) ),
 			)
 		);
 
@@ -231,6 +231,11 @@ class CKWC_Checkout {
 	 * when the opt-in checkbox is registered using add_opt_in_checkbox_as_additional_checkout_field().
 	 *
 	 * @since   1.9.1
+	 *
+	 * @param   string $key        Field Key.
+	 * @param   string $value      Field Value.
+	 * @param   string $group      Checkout Group (contact, address, order).
+	 * @param   mixed  $wc_object  WooCommerce object.
 	 */
 	public function save_opt_in_checkbox_additional_field( $key, $value, $group, $wc_object ) {
 

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -268,7 +268,7 @@ class CKWC_Order {
 				}
 
 				// Add subscriber to form.
-				$result = $this->api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'] );
+				$result = $this->api->add_subscriber_to_form( $resource_id, $subscriber['subscriber']['id'], home_url() );
 				break;
 
 			case 'tag':

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -107,6 +107,14 @@ class WP_CKWC {
 	 */
 	public function woocommerce_blocks_register() {
 
+		// 8.9.0 and higher replaces checkout block registrations with the `woocommerce_register_additional_checkout_field()` method,
+		// to register the opt in field when using the WooCommerce Checkout Block.
+		// See CKWC_Checkout, which uses this method.
+		if ( function_exists( 'woocommerce_register_additional_checkout_field' ) ) {
+			// The block won't display or be used in 8.9.0+ checkout, so there's no point registering it.
+			return;
+		}
+
 		// Load opt in checkbox block.
 		require_once CKWC_PLUGIN_PATH . '/includes/blocks/opt-in/class-ckwc-opt-in-block-integration.php';
 
@@ -226,8 +234,6 @@ class WP_CKWC {
 			return;
 		}
 
-		$this->classes['checkout'] = new CKWC_Checkout();
-
 		/**
 		 * Initialize integration classes for the frontend web site.
 		 *
@@ -245,6 +251,7 @@ class WP_CKWC {
 	 */
 	private function initialize_global() {
 
+		$this->classes['checkout'] = new CKWC_Checkout();
 		$this->classes['order']            = new CKWC_Order();
 		$this->classes['review_request']   = new ConvertKit_Review_Request( 'Kit for WooCommerce', 'convertkit-for-woocommerce', CKWC_PLUGIN_PATH );
 		$this->classes['setup']            = new CKWC_Setup();

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -251,7 +251,7 @@ class WP_CKWC {
 	 */
 	private function initialize_global() {
 
-		$this->classes['checkout'] = new CKWC_Checkout();
+		$this->classes['checkout']         = new CKWC_Checkout();
 		$this->classes['order']            = new CKWC_Order();
 		$this->classes['review_request']   = new ConvertKit_Review_Request( 'Kit for WooCommerce', 'convertkit-for-woocommerce', CKWC_PLUGIN_PATH );
 		$this->classes['setup']            = new CKWC_Setup();

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -222,7 +222,7 @@ class ConvertKitAPI extends \Codeception\Module
 	public function apiCustomFieldDataIsValid($I, $subscriber, $excludeNameFromAddress = false)
 	{
 		$I->assertEquals($subscriber['fields']['last_name'], 'Last');
-		$I->assertEquals($subscriber['fields']['phone_number'], '123-123-1234');
+		$I->assertEquals($subscriber['fields']['phone_number'], '1231231234');
 		$I->assertEquals($subscriber['fields']['billing_address'], ( $excludeNameFromAddress ? 'Address Line 1, City, CA 12345' : 'First Last, Address Line 1, City, CA 12345' ));
 		$I->assertEquals($subscriber['fields']['payment_method'], 'cod');
 		$I->assertEquals($subscriber['fields']['notes'], 'Notes');

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -222,7 +222,7 @@ class ConvertKitAPI extends \Codeception\Module
 	public function apiCustomFieldDataIsValid($I, $subscriber, $excludeNameFromAddress = false)
 	{
 		$I->assertEquals($subscriber['fields']['last_name'], 'Last');
-		$I->assertEquals($subscriber['fields']['phone_number'], '1231231234');
+		$I->assertEquals($subscriber['fields']['phone_number'], '6159684594');
 		$I->assertEquals($subscriber['fields']['billing_address'], ( $excludeNameFromAddress ? 'Address Line 1, City, CA 12345' : 'First Last, Address Line 1, City, CA 12345' ));
 		$I->assertEquals($subscriber['fields']['payment_method'], 'cod');
 		$I->assertEquals($subscriber['fields']['notes'], 'Notes');

--- a/tests/_support/Helper/Acceptance/ConvertKitAPI.php
+++ b/tests/_support/Helper/Acceptance/ConvertKitAPI.php
@@ -97,6 +97,46 @@ class ConvertKitAPI extends \Codeception\Module
 	}
 
 	/**
+	 * Check the given subscriber ID has been assigned to the given form ID.
+	 *
+	 * @since   1.9.1
+	 *
+	 * @param   AcceptanceTester $I             AcceptanceTester.
+	 * @param   int              $subscriberID  Subscriber ID.
+	 * @param   int              $formID        Form ID.
+	 * @param   string           $referrer      Referrer.
+	 */
+	public function apiCheckSubscriberHasForm($I, $subscriberID, $formID, $referrer = false)
+	{
+		// Run request.
+		$results = $this->apiRequest(
+			'forms/' . $formID . '/subscribers',
+			'GET',
+			[
+				// Check all subscriber states.
+				'status' => 'all',
+			]
+		);
+
+		// Iterate through subscribers.
+		$subscriberHasForm = false;
+		foreach ($results['subscribers'] as $subscriber) {
+			if ($subscriber['id'] === $subscriberID) {
+				$subscriberHasForm = true;
+				break;
+			}
+		}
+
+		// Assert if the subscriber has the form.
+		$this->assertTrue($subscriberHasForm);
+
+		// If a referrer is specified, assert it matches the subscriber's referrer now.
+		if ($referrer) {
+			$I->assertEquals($subscriber['referrer'], $referrer);
+		}
+	}
+
+	/**
 	 * Check the given order ID exists as a purchase on ConvertKit.
 	 *
 	 * @param   AcceptanceTester $I             AcceptanceTester.

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -289,15 +289,18 @@ class WooCommerce extends \Codeception\Module
 			$I->waitForText('Coupon code applied successfully.', 5, '.is-success');
 		}
 
+		// Determine field ID for opt-in checkbox.
+		$optInCheckboxFieldID = ( $options['use_legacy_checkout'] ? '#ckwc_opt_in' : '#billing-ckwc-opt-in' );
+
 		// Handle Opt-In Checkbox.
 		if ($options['display_opt_in']) {
 			if ($options['check_opt_in']) {
-				$I->checkOption('#ckwc_opt_in');
+				$I->checkOption($optInCheckboxFieldID);
 			} else {
-				$I->uncheckOption('#ckwc_opt_in');
+				$I->uncheckOption($optInCheckboxFieldID);
 			}
 		} else {
-			$I->dontSeeElement('#ckwc_opt_in');
+			$I->dontSeeElement($optInCheckboxFieldID);
 		}
 
 		// Click Place order button.

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -59,11 +59,30 @@ class WooCommerce extends \Codeception\Module
 				'payment_request_button_size'           => 'default',
 				'saved_cards'                           => 'no',
 				'logging'                               => 'no',
-				'upe_checkout_experience_enabled'       => 'disabled',
+				'upe_checkout_experience_enabled'       => 'yes',
 				'title_upe'                             => '',
 				'is_short_statement_descriptor_enabled' => 'no',
-				'upe_checkout_experience_accepted_payments' => [],
+				'upe_checkout_experience_accepted_payments' => [
+					'card',
+					'link',
+				],
 				'short_statement_descriptor'            => 'CK',
+				'stripe_upe_payment_method_order'       => [
+					'card',
+					'alipay',
+					'klarna',
+					'afterpay_clearpay',
+					'eps',
+					'bancontact',
+					'boleto',
+					'ideal',
+					'oxxo',
+					'sepa_debit',
+					'p24',
+					'multibanco',
+					'link',
+					'wechat_pay',
+				],
 			]
 		);
 	}
@@ -685,10 +704,9 @@ class WooCommerce extends \Codeception\Module
 			 */
 			case 'stripe':
 				// Complete Credit Card Details.
-				$I->wait(5);
 				$I->switchToIFrame('iframe[name^="__privateStripeFrame"]'); // Switch to Stripe iFrame.
-				$I->fillField('cardnumber', '4242424242424242');
-				$I->fillfield('exp-date', '01/26');
+				$I->fillField('number', '4242424242424242');
+				$I->fillfield('expiry', '01/26');
 				$I->fillField('cvc', '123');
 				$I->switchToIFrame(); // Switch back to main window.
 				break;

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -678,7 +678,7 @@ class WooCommerce extends \Codeception\Module
 				$I->fillField('#billing_address_1', 'Address Line 1');
 				$I->fillField('#billing_city', 'City');
 				$I->fillField('#billing_postcode', '12345');
-				$I->fillField('#billing_phone', '1231231234');
+				$I->fillField('#billing_phone', '6159684594');
 				$I->fillField('#billing_email', $emailAddress);
 				$I->fillField('#order_comments', 'Notes');
 				break;
@@ -690,7 +690,7 @@ class WooCommerce extends \Codeception\Module
 				$I->fillField('#billing-address_1', 'Address Line 1');
 				$I->fillField('#billing-city', 'City');
 				$I->fillField('#billing-postcode', '12345');
-				$I->fillField('#billing-phone', '1231231234');
+				$I->fillField('#billing-phone', '6159684594');
 				$I->fillField('#email', $emailAddress);
 				$I->checkOption('.wc-block-checkout__add-note input.wc-block-components-checkbox__input');
 				$I->fillField('.wc-block-components-textarea', 'Notes');

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -77,10 +77,7 @@ class WooCommerce extends \Codeception\Module
 	 */
 	public function setupWooCommerceHPOS($I)
 	{
-		$I->amOnAdminPage('admin.php?page=wc-settings&tab=advanced&section=features');
-		$I->waitForElementVisible('input[name="woocommerce_custom_orders_table_enabled"]');
-		$I->selectOption('input[name="woocommerce_custom_orders_table_enabled"]', 'yes');
-		$I->click('Save changes');
+		$I->haveOptionInDatabase('woocommerce_custom_orders_table_enabled', 'yes');
 	}
 
 	/**
@@ -662,7 +659,7 @@ class WooCommerce extends \Codeception\Module
 				$I->fillField('#billing_address_1', 'Address Line 1');
 				$I->fillField('#billing_city', 'City');
 				$I->fillField('#billing_postcode', '12345');
-				$I->fillField('#billing_phone', '123-123-1234');
+				$I->fillField('#billing_phone', '1231231234');
 				$I->fillField('#billing_email', $emailAddress);
 				$I->fillField('#order_comments', 'Notes');
 				break;
@@ -674,7 +671,7 @@ class WooCommerce extends \Codeception\Module
 				$I->fillField('#billing-address_1', 'Address Line 1');
 				$I->fillField('#billing-city', 'City');
 				$I->fillField('#billing-postcode', '12345');
-				$I->fillField('#billing-phone', '123-123-1234');
+				$I->fillField('#billing-phone', '1231231234');
 				$I->fillField('#email', $emailAddress);
 				$I->checkOption('.wc-block-checkout__add-note input.wc-block-components-checkbox__input');
 				$I->fillField('.wc-block-components-textarea', 'Notes');

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -304,7 +304,7 @@ class WooCommerce extends \Codeception\Module
 		switch ($options['use_legacy_checkout']) {
 			case true:
 				$I->waitForElementNotVisible('.blockOverlay');
-				$I->scrollTo('#order_review_heading');
+				$I->scrollTo('#place_order');
 				$I->click('#place_order');
 				break;
 
@@ -685,6 +685,7 @@ class WooCommerce extends \Codeception\Module
 			 */
 			case 'stripe':
 				// Complete Credit Card Details.
+				$I->wait(2);
 				$I->switchToIFrame('iframe[name^="__privateStripeFrame"]'); // Switch to Stripe iFrame.
 				$I->fillField('cardnumber', '4242424242424242');
 				$I->fillfield('exp-date', '01/26');

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -685,7 +685,7 @@ class WooCommerce extends \Codeception\Module
 			 */
 			case 'stripe':
 				// Complete Credit Card Details.
-				$I->wait(2);
+				$I->wait(5);
 				$I->switchToIFrame('iframe[name^="__privateStripeFrame"]'); // Switch to Stripe iFrame.
 				$I->fillField('cardnumber', '4242424242424242');
 				$I->fillfield('exp-date', '01/26');

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -346,7 +346,7 @@ class WooCommerce extends \Codeception\Module
 		// Confirm order received is displayed.
 		// WooCommerce changed the default wording between 5.x and 6.x, so perform
 		// a few checks to be certain.
-		$I->waitForElement('body.woocommerce-order-received');
+		$I->waitForElement('body.woocommerce-order-received', 30);
 		$I->seeInSource('Order');
 		$I->seeInSource('received');
 		$I->seeInSource('Order details</h3>');

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -18,6 +18,9 @@ class WooCommerce extends \Codeception\Module
 	 */
 	public function setupWooCommercePlugin($I)
 	{
+		// Set Store in Live mode i.e. not in "Coming Soon" mode.
+		$I->haveOptionInDatabase( 'woocommerce_coming_soon', 'no' );
+
 		// Setup Cash on Delivery as Payment Method.
 		$I->haveOptionInDatabase(
 			'woocommerce_cod_settings',

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -685,10 +685,6 @@ class WooCommerce extends \Codeception\Module
 			 */
 			case 'stripe':
 				// Complete Credit Card Details.
-				// Only need to click the label in the legacy checkout.
-				if ($useLegacyCheckout) {
-					$I->click('label[for="payment_method_stripe"]');
-				}
 				$I->switchToIFrame('iframe[name^="__privateStripeFrame"]'); // Switch to Stripe iFrame.
 				$I->fillField('cardnumber', '4242424242424242');
 				$I->fillfield('exp-date', '01/26');

--- a/tests/acceptance/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
+++ b/tests/acceptance/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Tests features that are supported in an older WooCommerce version, 8.4.0
+ *
+ * @since   1.9.1
+ */
+class SettingOptInCheckboxCest
+{
+	/**
+	 * Run common actions before running the test functions in this class.
+	 *
+	 * @since   1.9.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _before(AcceptanceTester $I)
+	{
+		// Activate Plugin.
+		$I->activateWooCommerceAndConvertKitPlugins($I);
+
+		// Setup WooCommerce Plugin.
+		$I->setupWooCommercePlugin($I);
+
+		// Enable Integration and define its Access and Refresh Tokens.
+		$I->setupConvertKitPlugin($I);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+	}
+
+	
+
+	/**
+	 * Deactivate and reset Plugin(s) after each test, if the test passes.
+	 * We don't use _after, as this would provide a screenshot of the Plugin
+	 * deactivation and not the true test error.
+	 *
+	 * @since   1.9.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function _passed(AcceptanceTester $I)
+	{
+		$I->deactivateWooCommerceAndConvertKitPlugins($I);
+		$I->resetConvertKitPlugin($I);
+	}
+}

--- a/tests/acceptance/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
+++ b/tests/acceptance/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
@@ -4,7 +4,7 @@
  *
  * @since   1.9.1
  */
-class SettingOptInCheckboxCest
+class BackwardCompatSettingOptInCheckboxCest
 {
 	/**
 	 * Run common actions before running the test functions in this class.
@@ -28,7 +28,53 @@ class SettingOptInCheckboxCest
 		$I->loadConvertKitSettingsScreen($I);
 	}
 
-	
+	/**
+	 * Test that the opt in checkbox block is automatically added to the WooCommerce Checkout
+	 * block, cannot be removed and links to the integration settings screen.
+	 *
+	 * @since   1.9.1
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testOptInCheckboxBlockInEditor(AcceptanceTester $I)
+	{
+		// Enable the Opt-In Checkbox option.
+		$I->checkOption('#woocommerce_ckwc_display_opt_in');
+
+		// Save.
+		$I->click('Save changes');
+
+		// Edit Checkout Page.
+		$pageID = $I->grabFromDatabase(
+			'wp_posts',
+			'ID',
+			[
+				'post_name' => 'checkout',
+			]
+		);
+		$I->amOnAdminPage('post.php?post=' . $pageID . '&action=edit');
+
+		// Close Gutenberg modal.
+		$I->maybeCloseGutenbergWelcomeModal($I);
+
+		// Confirm Checkout Block exists in Checkout.
+		$I->click('div[data-type="ckwc/opt-in"]');
+
+		// Confirm block cannot be deleted.
+		$I->click('button.components-dropdown-menu__toggle');
+		$I->waitForElementVisible('.components-popover');
+		$I->dontSee('Unlock', '.components-popover');
+		$I->dontSee('Delete', '.components-popover');
+
+		// Confirm Configure Opt In button.
+		$I->click('Configure Opt In');
+
+		// Switch to tab that opened.
+		$I->switchToNextTab();
+
+		// Confirm this displays the integration settings screen.
+		$I->seeCheckboxIsChecked('#woocommerce_ckwc_display_opt_in');
+	}
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.

--- a/tests/acceptance/settings/SettingOptInCheckboxCest.php
+++ b/tests/acceptance/settings/SettingOptInCheckboxCest.php
@@ -289,54 +289,6 @@ class SettingOptInCheckboxCest
 	}
 
 	/**
-	 * Test that the opt in checkbox block is automatically added to the WooCommerce Checkout
-	 * block, cannot be removed and links to the integration settings screen.
-	 *
-	 * @since   1.7.1
-	 *
-	 * @param   AcceptanceTester $I  Tester.
-	 */
-	public function testOptInCheckboxBlockInEditor(AcceptanceTester $I)
-	{
-		// Enable the Opt-In Checkbox option.
-		$I->checkOption('#woocommerce_ckwc_display_opt_in');
-
-		// Save.
-		$I->click('Save changes');
-
-		// Edit Checkout Page.
-		$pageID = $I->grabFromDatabase(
-			'wp_posts',
-			'ID',
-			[
-				'post_name' => 'checkout',
-			]
-		);
-		$I->amOnAdminPage('post.php?post=' . $pageID . '&action=edit');
-
-		// Close Gutenberg modal.
-		$I->maybeCloseGutenbergWelcomeModal($I);
-
-		// Confirm Checkout Block exists in Checkout.
-		$I->click('div[data-type="ckwc/opt-in"]');
-
-		// Confirm block cannot be deleted.
-		$I->click('button.components-dropdown-menu__toggle');
-		$I->waitForElementVisible('.components-popover');
-		$I->dontSee('Unlock', '.components-popover');
-		$I->dontSee('Delete', '.components-popover');
-
-		// Confirm Configure Opt In button.
-		$I->click('Configure Opt In');
-
-		// Switch to tab that opened.
-		$I->switchToNextTab();
-
-		// Confirm this displays the integration settings screen.
-		$I->seeCheckboxIsChecked('#woocommerce_ckwc_display_opt_in');
-	}
-
-	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/acceptance/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
@@ -62,6 +62,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		// in the integration's settings.
 		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 
@@ -125,6 +133,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		// Confirm that the email address was added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
 		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
@@ -166,6 +182,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
 
@@ -204,6 +228,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.

--- a/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -62,6 +62,14 @@ class SubscribeOnOrderCompletedEventCest
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 	}
@@ -128,6 +136,14 @@ class SubscribeOnOrderCompletedEventCest
 
 		// Confirm that the email address was added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -56,6 +56,14 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 	}
@@ -111,6 +119,14 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Confirm that the email address was added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 	}
@@ -143,6 +159,14 @@ class SubscribeOnOrderPendingPaymentEventCest
 
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -181,6 +205,14 @@ class SubscribeOnOrderPendingPaymentEventCest
 
 		// Confirm that the email address was now added to ConvertKit.
 		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -61,6 +61,14 @@ class SubscribeOnOrderProcessingEventCest
 		// in the integration's settings.
 		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 
@@ -126,6 +134,14 @@ class SubscribeOnOrderProcessingEventCest
 		// in the integration's settings.
 		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 
@@ -165,6 +181,14 @@ class SubscribeOnOrderProcessingEventCest
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
 
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
+
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 	}
@@ -203,6 +227,14 @@ class SubscribeOnOrderProcessingEventCest
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
 		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['TEST_SITE_WP_URL']
+		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);


### PR DESCRIPTION
## Summary

WooCommerce 8.9.0, released May 2024, introduced the `woocommerce_register_additional_checkout_field` method, providing a PHP method for registering fields on the WooCommerce Checkout block.

Previously, this method wasn't available, which is why [this PR in December 2023](https://github.com/Kit/convertkit-woocommerce/pull/167) provided an opt-in block for the WooCommerce Checkout block.

This new method is designed to replace the opt-in block, although the opt-in block is retained for installations < 8.9.0 that use the Checkout block experience.

<img width="1333" alt="Screenshot 2025-01-14 at 22 51 42" src="https://github.com/user-attachments/assets/e0252508-36db-4063-8337-41889da89bda" />

## Testing

Existing tests pass. Changes to tests made to support:
- WooCommerce Stripe Gateway 9.1.0
- WooCommerce Subscriptions 7.0.0

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)