### PR TITLE
Fix Sync Past Orders when Refund Orders exist

### DIFF
--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -413,7 +413,19 @@ class CKWC_Order {
 				'convertkit_for_woocommerce_error_order_missing',
 				sprintf(
 					/* translators: WooCommerce Order ID */
-					__( 'Order ID %s could not be found in WooCommerce.', 'woocommerce-convertkit' ),
+					__( 'Order ID #%s could not be found in WooCommerce.', 'woocommerce-convertkit' ),
+					$order_id
+				)
+			);
+		}
+
+		// If the Order is a refund, skip it.
+		if ( $order instanceof \Automattic\WooCommerce\Admin\Overrides\OrderRefund ) {
+			return new WP_Error(
+				'convertkit_for_woocommerce_error_order_refund',
+				sprintf(
+					/* translators: WooCommerce Order ID */
+					__( 'Order ID #%s is a refund. Skipping...', 'woocommerce-convertkit' ),
 					$order_id
 				)
 			);
@@ -427,7 +439,7 @@ class CKWC_Order {
 				'convertkit_for_woocommerce_error_order_exists',
 				sprintf(
 					/* translators: WooCommerce Order ID */
-					__( 'Order ID %s has already been sent to Kit.', 'woocommerce-convertkit' ),
+					__( 'Order ID #%s has already been sent to Kit.', 'woocommerce-convertkit' ),
 					$order_id
 				)
 			);

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -712,6 +712,8 @@ class CKWC_Order {
 				// Query HPOS.
 				$query = new WC_Order_Query(
 					array(
+						// Return posts of type `shop_order`.
+						'type'       => 'shop_order',
 						'limit'      => -1,
 
 						// Only include Orders that do not match the Purchase Data Event integration setting.

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -41,8 +41,16 @@ class WPBulkEdit extends \Codeception\Module
 			}
 		}
 
-		// Scroll to Stock Quantity.
-		$I->scrollTo('select.change_stock');
+		switch ( $noticePostType ) {
+			case 'coupon':
+				// Scroll to Bulk Edit label.
+				$I->scrollTo('#bulk-edit-legend');
+				break;
+			default:
+				// Scroll to Stock Quantity.
+				$I->scrollTo('select.change_stock');
+				break;
+		}
 
 		// Click Update.
 		$I->click('Update');

--- a/tests/_support/Helper/Acceptance/WPBulkEdit.php
+++ b/tests/_support/Helper/Acceptance/WPBulkEdit.php
@@ -41,8 +41,8 @@ class WPBulkEdit extends \Codeception\Module
 			}
 		}
 
-		// Scroll to Bulk Edit label.
-		$I->scrollTo('#bulk-edit-legend');
+		// Scroll to Stock Quantity.
+		$I->scrollTo('select.change_stock');
 
 		// Click Update.
 		$I->click('Update');

--- a/tests/_support/Helper/Acceptance/WooCommerce.php
+++ b/tests/_support/Helper/Acceptance/WooCommerce.php
@@ -394,6 +394,41 @@ class WooCommerce extends \Codeception\Module
 	}
 
 	/**
+	 * Refunds the given Order ID.
+	 *
+	 * @since   1.9.2
+	 *
+	 * @param   AcceptanceTester $I              Acceptance Tester.
+	 * @param   int              $orderID        WooCommerce Order ID.
+	 * @param   int              $amount         Amount to refund.
+	 */
+	public function wooCommerceRefundOrder($I, $orderID, $amount)
+	{
+		// We perform the order status change by editing the Order as a WordPress Administrator would,
+		// so that WooCommerce triggers its actions and filters that our integration hooks into.
+		$I->loginAsAdmin();
+
+		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
+		if (strpos($orderID, '-') !== false) {
+			$orderIDParts = explode('-', $orderID);
+			$orderID      = $orderIDParts[ count($orderIDParts) - 1 ];
+		}
+
+		// Load order edit screen.
+		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');
+
+		// Refund the entire order.
+		$I->click('button.refund-items');
+		$I->waitForElementVisible('input#refund_amount');
+		$I->fillField('input#refund_amount', $amount);
+		$I->click('button.do-manual-refund');
+		$I->acceptPopup();
+
+		// Wait for confirmation.
+		$I->waitForElementVisible('abbr.refund_by');
+	}
+
+	/**
 	 * Creates a 'Simple product' in WooCommerce that can be used for tests.
 	 *
 	 * @since   1.0.0

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
@@ -136,6 +136,37 @@ class SyncPastOrdersCest
 	}
 
 	/**
+	 * Test that no button is displayed on the Integration Settings screen
+	 * when:
+	 * - the Integration is enabled,
+	 * - valid API credentials are specified,
+	 * - a WooCommerce Order exists, that has been refunded.
+	 *
+	 * @since   1.9.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSyncPastOrderExcludesRefunds(AcceptanceTester $I)
+	{
+		// Delete all existing WooCommerce Orders from the database.
+		$I->wooCommerceDeleteAllOrders($I);
+
+		// Create Product and Checkout for this test, sending the Order
+		// to Kit.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
+
+		// Refund the Order.
+		$I->wooCommerceRefundOrder($I, $result['order_id'], 10);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Confirm that no Sync Past Order button is displayed, as the Order
+		// is fully refunded.
+		$I->dontSeeElementInDOM('a#ckwc_sync_past_orders');
+	}
+
+	/**
 	 * Test that a button is displayed on the Integration Settings screen
 	 * when:
 	 * - the Integration is enabled,

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCest.php
@@ -140,6 +140,37 @@ class SyncPastOrdersHPOSCest
 	}
 
 	/**
+	 * Test that no button is displayed on the Integration Settings screen
+	 * when:
+	 * - the Integration is enabled,
+	 * - valid API credentials are specified,
+	 * - a WooCommerce Order exists, that has been refunded.
+	 *
+	 * @since   1.9.2
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSyncPastOrderExcludesRefunds(AcceptanceTester $I)
+	{
+		// Delete all existing WooCommerce Orders from the database.
+		$I->wooCommerceDeleteAllOrders($I);
+
+		// Create Product and Checkout for this test, sending the Order
+		// to Kit.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
+
+		// Refund the Order.
+		$I->wooCommerceRefundOrder($I, $result['order_id'], 10);
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Confirm that no Sync Past Order button is displayed, as the Order
+		// is fully refunded.
+		$I->dontSeeElementInDOM('a#ckwc_sync_past_orders');
+	}
+
+	/**
 	 * Test that a button is displayed on the Integration Settings screen
 	 * when:
 	 * - the Integration is enabled,

--- a/views/backend/settings/sync-past-orders.php
+++ b/views/backend/settings/sync-past-orders.php
@@ -13,7 +13,7 @@
 	<h2><?php echo esc_html( $this->get_method_title() ); ?></h2>
 
 	<p>
-		<?php esc_html_e( 'Do not navigate away from this page until the process is completed, otherwise complete purchase data will not be sent to ConvertKit. You will be notified via this page when the process is completed.', 'woocommerce-convertkit' ); ?>
+		<?php esc_html_e( 'Do not navigate away from this page until the process is completed, otherwise complete purchase data will not be sent to Kit. You will be notified via this page when the process is completed.', 'woocommerce-convertkit' ); ?>
 	</p>
 
 	<!-- Progress Bar -->


### PR DESCRIPTION
## Summary

Fixes this reported issue, where refund orders were incorrectly included in the Sync Past Orders functionality of this Plugin, due to the `type` filter missing when fetching Orders needing to be sent to Kit's `purchases` endpoint when WooCommerce's HPOS is enabled.

## Testing

- `SyncPastOrdersTest:testSyncPastOrderExcludesRefunds`: Test that no sync past orders button is displayed when a WooCommerce Order is refunded.
- `SyncPastOrdersHPOSTest:testSyncPastOrderExcludesRefunds`: Test that no sync past orders button is displayed when a WooCommerce Order is refunded and HPOS is enabled.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)