### PR TITLE
Sync Past Orders: Exclude Orders with no Email Address

### DIFF
--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -675,7 +675,7 @@ class CKWC_Order {
 		switch ( get_option( 'woocommerce_custom_orders_table_enabled' ) ) {
 			case 'no':
 				// Query CPT.
-				// We can't use WC_Order_Quey with a meta_query when HPOS is disabled:
+				// We can't use WC_Order_Query with a meta_query when HPOS is disabled:
 				// https://github.com/woocommerce/woocommerce/pull/47457.
 				$query = new WP_Query(
 					array(
@@ -686,11 +686,17 @@ class CKWC_Order {
 						// Only include Orders that do not match the Purchase Data Event integration setting.
 						'post_status'    => $post_statuses,
 
-						// Only include Orders that do not have a ConvertKit Purchase Data ID.
+						// Only include Orders that do not have a ConvertKit Purchase Data ID
+						// and have an email address.
 						'meta_query'     => array(
 							array(
 								'key'     => 'ckwc_purchase_data_id',
 								'compare' => 'NOT EXISTS',
+							),
+							array(
+								'key'     => '_billing_email',
+								'value'   => '',
+								'compare' => '!=',
 							),
 						),
 
@@ -713,22 +719,31 @@ class CKWC_Order {
 				$query = new WC_Order_Query(
 					array(
 						// Return posts of type `shop_order`.
-						'type'       => 'shop_order',
-						'limit'      => -1,
+						'type'        => 'shop_order',
+						'limit'       => -1,
 
 						// Only include Orders that do not match the Purchase Data Event integration setting.
-						'status'     => $post_statuses,
+						'status'      => $post_statuses,
 
 						// Only include Orders that do not have a ConvertKit Purchase Data ID.
-						'meta_query' => array(
+						'meta_query'  => array(
 							array(
 								'key'     => 'ckwc_purchase_data_id',
 								'compare' => 'NOT EXISTS',
 							),
 						),
 
+						// Only include Orders that have an email address.
+						'field_query' => array(
+							array(
+								'field'   => 'billing_email',
+								'value'   => '',
+								'compare' => '!=',
+							),
+						),
+
 						// Only return Order IDs.
-						'return'     => 'ids',
+						'return'      => 'ids',
 					)
 				);
 

--- a/tests/acceptance/purchase-data/PurchaseDataCest.php
+++ b/tests/acceptance/purchase-data/PurchaseDataCest.php
@@ -19,9 +19,6 @@ class PurchaseDataCest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
-		// Enable HPOS.
-		$I->setupWooCommerceHPOS($I);
-
 		// Activate Custom Order Numbers, so that we can prefix Order IDs with
 		// an environment-specific string.
 		$I->activateThirdPartyPlugin($I, 'custom-order-numbers-for-woocommerce');

--- a/tests/acceptance/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
@@ -20,9 +20,6 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
-		// Enable HPOS.
-		$I->setupWooCommerceHPOS($I);
-
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 

--- a/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -19,9 +19,6 @@ class SubscribeOnOrderCompletedEventCest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
-		// Enable HPOS.
-		$I->setupWooCommerceHPOS($I);
-
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 

--- a/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -19,9 +19,6 @@ class SubscribeOnOrderPendingPaymentEventCest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
-		// Enable HPOS.
-		$I->setupWooCommerceHPOS($I);
-
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 

--- a/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/acceptance/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -20,9 +20,6 @@ class SubscribeOnOrderProcessingEventCest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
-		// Enable HPOS.
-		$I->setupWooCommerceHPOS($I);
-
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCLICest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCLICest.php
@@ -18,6 +18,9 @@ class SyncPastOrdersCLICest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
+		// Disable HPOS.
+		$I->disableWooCommerceHPOS($I);
+
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
@@ -18,6 +18,9 @@ class SyncPastOrdersCest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
+		// Disable HPOS.
+		$I->disableWooCommerceHPOS($I);
+
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 
@@ -163,6 +166,50 @@ class SyncPastOrdersCest
 
 		// Confirm that no Sync Past Order button is displayed, as the Order
 		// is fully refunded.
+		$I->dontSeeElementInDOM('a#ckwc_sync_past_orders');
+	}
+
+	/**
+	 * Test that no button is displayed on the Integration Settings screen
+	 * when:
+	 * - the Integration is enabled,
+	 * - valid API credentials are specified,
+	 * - a WooCommerce Order exists, that has no email address.
+	 *
+	 * @since   1.9.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSyncPastOrderExcludesOrdersWithNoEmailAddress(AcceptanceTester $I)
+	{
+		// Delete all existing WooCommerce Orders from the database.
+		$I->wooCommerceDeleteAllOrders($I);
+
+		// Create Product and Checkout for this test, not sending the Order
+		// to ConvertKit.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'send_purchase_data' => false,
+			]
+		);
+
+		// Login as the Administrator.
+		$I->loginAsAdmin();
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Confirm that the Sync Past Order button is displayed.
+		$I->seeElementInDOM('a#ckwc_sync_past_orders');
+
+		// Remove the email address from the Order.
+		$I->wooCommerceChangeOrderEmailAddress($I, $result['order_id'], '');
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Confirm that no Sync Past Order button is displayed.
 		$I->dontSeeElementInDOM('a#ckwc_sync_past_orders');
 	}
 

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersCest.php
@@ -279,8 +279,8 @@ class SyncPastOrdersCest
 		$I->seeInSource('Enable Kit integration');
 
 		// Confirm that the Transaction ID is stored in the Order's metadata.
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_sent', 'yes', true);
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_id', $purchaseDataID, true);
+		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_sent', 'yes');
+		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_id', $purchaseDataID);
 	}
 
 	/**
@@ -323,7 +323,7 @@ class SyncPastOrdersCest
 
 		// Remove the Transaction ID metadata in the Order, as if it were sent
 		// by 1.4.2 or older.
-		$I->wooCommerceOrderDeleteMeta($I, $postID, 'ckwc_purchase_data_id', true);
+		$I->wooCommerceOrderDeleteMeta($I, $postID, 'ckwc_purchase_data_id');
 
 		// Login as the Administrator.
 		$I->loginAsAdmin();
@@ -353,8 +353,8 @@ class SyncPastOrdersCest
 		$I->seeElementInDOM('a.cancel[disabled]');
 
 		// Confirm that the Transaction ID is stored in the Order's metadata.
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_sent', 'yes', true);
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_id', $purchaseDataID, true);
+		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_sent', 'yes');
+		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_id', $purchaseDataID);
 	}
 
 	/**

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCLICest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCLICest.php
@@ -19,9 +19,6 @@ class SyncPastOrdersHPOSCLICest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
-		// Enable HPOS.
-		$I->setupWooCommerceHPOS($I);
-
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCLICest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCLICest.php
@@ -19,6 +19,9 @@ class SyncPastOrdersHPOSCLICest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
+		// Enable HPOS.
+		$I->enableWooCommerceHPOS($I);
+
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCest.php
@@ -19,9 +19,6 @@ class SyncPastOrdersHPOSCest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
-		// Enable HPOS.
-		$I->setupWooCommerceHPOS($I);
-
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 
@@ -167,6 +164,50 @@ class SyncPastOrdersHPOSCest
 
 		// Confirm that no Sync Past Order button is displayed, as the Order
 		// is fully refunded.
+		$I->dontSeeElementInDOM('a#ckwc_sync_past_orders');
+	}
+
+	/**
+	 * Test that no button is displayed on the Integration Settings screen
+	 * when:
+	 * - the Integration is enabled,
+	 * - valid API credentials are specified,
+	 * - a WooCommerce Order exists, that has no email address.
+	 *
+	 * @since   1.9.3
+	 *
+	 * @param   AcceptanceTester $I  Tester.
+	 */
+	public function testSyncPastOrderExcludesOrdersWithNoEmailAddress(AcceptanceTester $I)
+	{
+		// Delete all existing WooCommerce Orders from the database.
+		$I->wooCommerceDeleteAllOrders($I);
+
+		// Create Product and Checkout for this test, not sending the Order
+		// to ConvertKit.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'send_purchase_data' => false,
+			]
+		);
+
+		// Login as the Administrator.
+		$I->loginAsAdmin();
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Confirm that the Sync Past Order button is displayed.
+		$I->seeElementInDOM('a#ckwc_sync_past_orders');
+
+		// Remove the email address from the Order.
+		$I->wooCommerceChangeOrderEmailAddress($I, $result['order_id'], '');
+
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
+		// Confirm that no Sync Past Order button is displayed.
 		$I->dontSeeElementInDOM('a#ckwc_sync_past_orders');
 	}
 

--- a/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCest.php
+++ b/tests/acceptance/sync-past-orders/SyncPastOrdersHPOSCest.php
@@ -19,6 +19,9 @@ class SyncPastOrdersHPOSCest
 		// Activate Plugin.
 		$I->activateWooCommerceAndConvertKitPlugins($I);
 
+		// Enable HPOS.
+		$I->enableWooCommerceHPOS($I);
+
 		// Setup WooCommerce Plugin.
 		$I->setupWooCommercePlugin($I);
 


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://linear.app/kit/issue/WP-23/kit-for-woocommerce-sync-past-orders-dont-sync-orders-with-invalid-no), where Orders containing no email address are attempted to be sent to the purchases API endpoint through the Sync Past Orders functionality, resulting in expected errors due to there being no email address.

## Testing

- `testSyncPastOrderExcludesOrdersWithNoEmailAddress`: Test that Orders with no email address are excluded from being sent to Kit's purchases endpoint, in both HPOS and non-HPOS environments.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)