### PR TITLE
Tests: Add compatibility with chromedriver v134

### DIFF
--- a/includes/class-ckwc-setup.php
+++ b/includes/class-ckwc-setup.php
@@ -79,7 +79,8 @@ class CKWC_Setup {
 		$api    = new CKWC_API( CKWC_OAUTH_CLIENT_ID, CKWC_OAUTH_CLIENT_REDIRECT_URI );
 		$result = $api->get_access_token_by_api_key_and_secret(
 			$integration->get_api_key(),
-			$integration->get_api_secret()
+			$integration->get_api_secret(),
+			get_site_url()
 		);
 
 		// Bail if an error occured.

--- a/includes/class-wp-ckwc.php
+++ b/includes/class-wp-ckwc.php
@@ -56,9 +56,6 @@ class WP_CKWC {
 		// Update.
 		add_action( 'convertkit_for_woocommerce_initialize_global', array( $this, 'update' ) );
 
-		// Load language files.
-		add_action( 'init', array( $this, 'load_language_files' ) );
-
 	}
 
 	/**
@@ -276,20 +273,6 @@ class WP_CKWC {
 	public function update() {
 
 		$this->get_class( 'setup' )->update();
-
-	}
-
-	/**
-	 * Loads plugin textdomain
-	 *
-	 * @since   1.0.0
-	 */
-	public function load_language_files() {
-
-		// If the .mo file for a given language is available in WP_LANG_DIR/convertkit
-		// i.e. it's available as a translation at https://translate.wordpress.org/projects/wp-plugins/convertkit-for-woocommerce/,
-		// it will be used instead of the .mo file in convertkit-for-woocommerce/languages.
-		load_plugin_textdomain( 'woocommerce-convertkit', false, 'convertkit-for-woocommerce/languages' );
 
 	}
 

--- a/tests/EndToEnd/general/ProductCest.php
+++ b/tests/EndToEnd/general/ProductCest.php
@@ -221,10 +221,13 @@ class ProductCest
 
 		// Reload the Products admin screen.
 		$I->amOnAdminPage('edit.php?post_type=product');
+		$I->waitForElementVisible('body.post-type-product');
 
 		// Confirm CSS and JS is output by the Plugin.
 		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/bulk-quick-edit.css', 'ckwc-bulk-quick-edit-css' );
 		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/quick-edit.js' );
+
+		$I->wait(1);
 
 		// Confirm that the chosen Resource is the selected option.
 		$I->seePostMetaInDatabase(

--- a/tests/EndToEnd/general/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/UpgradePathsCest.php
@@ -68,7 +68,7 @@ class UpgradePathsCest
 		// Save changes (avoids a JS alert box which would prevent other tests from running due to changes made on screen).
 		$I->click('Save changes');
 
-		// Wait for something.
+		// Wait for settings to save.
 		$I->waitForElementVisible('div.updated.inline');
 		$I->see('Your settings have been saved.');
 	}

--- a/tests/EndToEnd/general/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/UpgradePathsCest.php
@@ -67,6 +67,10 @@ class UpgradePathsCest
 
 		// Save changes (avoids a JS alert box which would prevent other tests from running due to changes made on screen).
 		$I->click('Save changes');
+
+		// Wait for something.
+		$I->waitForElementVisible('div.updated.inline');
+		$I->see('Your settings have been saved.');
 	}
 
 	/**

--- a/tests/EndToEnd/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
+++ b/tests/EndToEnd/integrations/WooCommerceSubscriptionsSubscribeEventCest.php
@@ -72,6 +72,9 @@ class WooCommerceSubscriptionsSubscribeEventCest
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 
+		// Logout as the customer.
+		$I->logOut();
+
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
 
@@ -125,6 +128,9 @@ class WooCommerceSubscriptionsSubscribeEventCest
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
+
+		// Logout as the customer.
+		$I->logOut();
 	}
 
 	/**

--- a/tests/EndToEnd/settings/SettingImportExportCest.php
+++ b/tests/EndToEnd/settings/SettingImportExportCest.php
@@ -77,6 +77,9 @@ class SettingImportExportCest
 		// Click the Save changes button.
 		$I->click('Save changes');
 
+		// Wait for confirmation message to display.
+		$I->waitForElementVisible('div.updated.inline');
+
 		// Confirm success message displays.
 		$I->seeInSource('Configuration imported successfully.');
 
@@ -107,6 +110,9 @@ class SettingImportExportCest
 		// Click the Save changes button.
 		$I->click('Save changes');
 
+		// Wait for error message to display.
+		$I->waitForElementVisible('div.error.inline');
+
 		// Confirm error message displays.
 		$I->seeInSource('The uploaded configuration file contains no settings.');
 	}
@@ -129,6 +135,9 @@ class SettingImportExportCest
 
 		// Click the Save changes button.
 		$I->click('Save changes');
+
+		// Wait for error message to display.
+		$I->waitForElementVisible('div.error.inline');
 
 		// Confirm error message displays.
 		$I->seeInSource('The uploaded configuration file isn\'t valid.');

--- a/tests/EndToEnd/settings/SettingOAuthCest.php
+++ b/tests/EndToEnd/settings/SettingOAuthCest.php
@@ -132,10 +132,14 @@ class SettingOAuthCest
 		// Save changes.
 		$I->click('Save changes');
 
+		// Wait for confirmation message to display.
+		$I->waitForElementVisible('div.updated.inline');
+
 		// Disconnect the Plugin connection to ConvertKit.
 		$I->click('Disconnect');
 
 		// Confirm the Connect button displays.
+		$I->waitForElementVisible('#oauth a.button-primary');
 		$I->see('Connect');
 		$I->dontSee('Disconnect');
 		$I->dontSeeElementInDOM('button.woocommerce-save-button');

--- a/tests/EndToEnd/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/EndToEnd/sync-past-orders/SyncPastOrdersCest.php
@@ -77,8 +77,10 @@ class SyncPastOrdersCest
 			'order_id'      => (int) $I->grabTextFrom('ul.wc-block-order-confirmation-summary-list li:first-child span.wc-block-order-confirmation-summary-list-item__value'),
 		];
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -199,8 +201,10 @@ class SyncPastOrdersCest
 			]
 		);
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -239,8 +243,10 @@ class SyncPastOrdersCest
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -330,8 +336,10 @@ class SyncPastOrdersCest
 		// by 1.4.2 or older.
 		$I->wooCommerceOrderDeleteMeta($I, $postID, 'ckwc_purchase_data_id');
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -380,8 +388,10 @@ class SyncPastOrdersCest
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Specify invalid API credentials.
 		$I->haveOptionInDatabase(

--- a/tests/EndToEnd/sync-past-orders/SyncPastOrdersHPOSCest.php
+++ b/tests/EndToEnd/sync-past-orders/SyncPastOrdersHPOSCest.php
@@ -78,8 +78,10 @@ class SyncPastOrdersHPOSCest
 			'order_id'      => (int) $I->grabTextFrom('ul.wc-block-order-confirmation-summary-list li:first-child span.wc-block-order-confirmation-summary-list-item__value'),
 		];
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -200,8 +202,10 @@ class SyncPastOrdersHPOSCest
 			]
 		);
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -240,8 +244,10 @@ class SyncPastOrdersHPOSCest
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -331,8 +337,10 @@ class SyncPastOrdersHPOSCest
 		// by 1.4.2 or older.
 		$I->wooCommerceOrderDeleteMeta($I, $postID, 'ckwc_purchase_data_id', true);
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -381,8 +389,10 @@ class SyncPastOrdersHPOSCest
 		// to ConvertKit.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Specify invalid API credentials.
 		$I->haveOptionInDatabase(

--- a/tests/Support/Data/dump.sql
+++ b/tests/Support/Data/dump.sql
@@ -243,7 +243,8 @@ INSERT INTO `wp_options` (`option_id`, `option_name`, `option_value`, `autoload`
 (126, 'WishListMemberOptions_Migrated', '1',  'yes'),
 (127, 'widget_wishlistwidget',  'a:1:{s:12:\"_multiwidget\";i:1;}', 'yes'),
 (128, 'WishListMemberOptions_MigrateLevelData', '1',  'yes'),
-(129, 'WishListMemberOptions_MigrateContentLevelData',  '1',  'yes');
+(129, 'WishListMemberOptions_MigrateContentLevelData',  '1',  'yes'),
+(130, 'woocommerce_version',  '9.7.1',  'yes');
 
 DROP TABLE IF EXISTS `wp_postmeta`;
 CREATE TABLE `wp_postmeta` (

--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -22,8 +22,8 @@ class ThirdPartyPlugin extends \Codeception\Module
 	public function activateThirdPartyPlugin($I, $name, $wizardExpectsToDisplay = true)
 	{
 		// Login as the Administrator, if we're not already logged in.
-		if ( ! $this->amLoggedInAsAdmin($I) ) {
-			$this->doLoginAsAdmin($I);
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
 		}
 
 		// Go to the Plugins screen in the WordPress Administration interface.
@@ -66,8 +66,8 @@ class ThirdPartyPlugin extends \Codeception\Module
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
 		// Login as the Administrator, if we're not already logged in.
-		if ( ! $this->amLoggedInAsAdmin($I) ) {
-			$this->doLoginAsAdmin($I);
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
 		}
 
 		// Go to the Plugins screen in the WordPress Administration interface.

--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -15,21 +15,27 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 *
 	 * @since   1.9.6.7
 	 *
-	 * @param   EndToEndTester $I     EndToEndTester.
-	 * @param   string         $name  Plugin Slug.
+	 * @param   EndToEndTester $I                       EndToEndTester.
+	 * @param   string         $name                    Plugin Slug.
+	 * @param   bool           $wizardExpectsToDisplay  Whether the Plugin Setup Wizard is expected to display.
 	 */
-	public function activateThirdPartyPlugin($I, $name)
+	public function activateThirdPartyPlugin($I, $name, $wizardExpectsToDisplay = true)
 	{
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $this->amLoggedInAsAdmin($I) ) {
+			$this->doLoginAsAdmin($I);
+		}
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
+		// Wait for the Plugins page to load.
+		$I->waitForElementVisible('body.plugins-php');
+
 		// Depending on the Plugin name, perform activation.
 		switch ($name) {
 			case 'woocommerce':
-				// The bulk action to activate won't be available in WordPress 6.5 due to dependent
+				// The bulk action to activate won't be available in WordPress 6.5+ due to dependent
 				// plugins being installed.
 				// See https://core.trac.wordpress.org/ticket/60863.
 				$I->click('a#activate-' . $name);
@@ -41,12 +47,8 @@ class ThirdPartyPlugin extends \Codeception\Module
 				break;
 		}
 
-		// Go to the Plugins screen again; this prevents any Plugin that loads a wizard-style screen from
-		// causing seePluginActivated() to fail.
-		$I->amOnPluginsPage();
-
-		// Check that the Plugin activated successfully.
-		$I->seePluginActivated($name);
+		// Wait for the Plugins page to load with the Plugin activated, to confirm it activated.
+		$I->waitForElementVisible('table.plugins tr[data-slug=' . $name . '].active');
 
 		// Check that no PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -58,36 +60,85 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 *
 	 * @since   1.9.6.7
 	 *
-	 * @param   EndToEndTester $I      Acceptance Tester.
+	 * @param   EndToEndTester $I      EndToEnd Tester.
 	 * @param   string         $name   Plugin Slug.
 	 */
 	public function deactivateThirdPartyPlugin($I, $name)
 	{
-		// Login as the Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $this->amLoggedInAsAdmin($I) ) {
+			$this->doLoginAsAdmin($I);
+		}
 
 		// Go to the Plugins screen in the WordPress Administration interface.
 		$I->amOnPluginsPage();
 
-		// Depending on the Plugin name, perform activation.
+		// Wait for the Plugins page to load.
+		$I->waitForElementVisible('body.plugins-php');
+
+		// Depending on the Plugin name, perform deactivation.
 		switch ($name) {
 			case 'woocommerce':
-				// The bulk action to deactivate won't be available in WordPress 6.5 due to dependent
+				// The bulk action to deactivate won't be available in WordPress 6.5+ due to dependent
 				// plugins being installed.
 				// See https://core.trac.wordpress.org/ticket/60863.
 				$I->click('a#deactivate-' . $name);
 				break;
 
 			default:
-				// Dectivate the Plugin.
+				// Deactivate the Plugin.
 				$I->deactivatePlugin($name);
 				break;
 		}
+	}
 
-		// Check that the Plugin deactivated successfully.
-		$I->seePluginDeactivated($name);
+	/**
+	 * Helper method to check if the Administrator is logged in.
+	 *
+	 * @since   2.7.6
+	 *
+	 * @param   EndToEndTester $I      EndToEnd Tester.
+	 *
+	 * @return  bool
+	 */
+	public function amLoggedInAsAdmin($I)
+	{
+		$cookies = $I->grabCookiesWithPattern('/^wordpress_logged_in_[a-z0-9]{32}$/');
+		return ! is_null( $cookies );
+	}
 
-		// Check that no PHP warnings or notices were output.
-		$I->checkNoWarningsAndNoticesOnScreen($I);
+	/**
+	 * Helper method to reliably login as the Administrator.
+	 *
+	 * @since   2.7.6
+	 *
+	 * @param   EndToEndTester $I      EndToEnd Tester.
+	 */
+	public function doLoginAsAdmin($I)
+	{
+		// Add admin_email_lifespan option to prevent Administration email verification screen from
+		// displaying on login, which causes tests to fail.
+		// This is included in the dump.sql file, but seems to be deleted after a test.
+		$I->haveOptionInDatabase('admin_email_lifespan', '1805512805');
+
+		// Load login screen.
+		$I->amOnPage('wp-login.php');
+
+		// Wait for the login form to load.
+		$I->waitForElementVisible('#user_login');
+		$I->waitForElementVisible('#user_pass');
+		$I->waitForElementVisible('#wp-submit');
+
+		// Fill in the login form.
+		$I->click('#user_login');
+		$I->fillField('#user_login', $_ENV['WORDPRESS_ADMIN_USER']);
+		$I->click('#user_pass');
+		$I->fillField('#user_pass', $_ENV['WORDPRESS_ADMIN_PASSWORD']);
+
+		// Submit.
+		$I->click('#wp-submit');
+
+		// Wait for the Dashboard page to load, to confirm login succeeded.
+		$I->waitForElementVisible('body.index-php');
 	}
 }

--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -17,9 +17,8 @@ class ThirdPartyPlugin extends \Codeception\Module
 	 *
 	 * @param   EndToEndTester $I                       EndToEndTester.
 	 * @param   string         $name                    Plugin Slug.
-	 * @param   bool           $wizardExpectsToDisplay  Whether the Plugin Setup Wizard is expected to display.
 	 */
-	public function activateThirdPartyPlugin($I, $name, $wizardExpectsToDisplay = true)
+	public function activateThirdPartyPlugin($I, $name)
 	{
 		// Login as the Administrator, if we're not already logged in.
 		if ( ! $I->amLoggedInAsAdmin($I) ) {

--- a/tests/Support/Helper/WooCommerce.php
+++ b/tests/Support/Helper/WooCommerce.php
@@ -311,6 +311,7 @@ class WooCommerce extends \Codeception\Module
 
 		// Apply Coupon Code.
 		if (isset($couponID)) {
+			$I->waitForElementVisible('a.showcoupon');
 			$I->click('a.showcoupon');
 			$I->waitForElementNotVisible('.blockOverlay');
 			$I->waitForElementVisible('input#coupon_code');
@@ -383,7 +384,10 @@ class WooCommerce extends \Codeception\Module
 	{
 		// We perform the order status change by editing the Order as a WordPress Administrator would,
 		// so that WooCommerce triggers its actions and filters that our integration hooks into.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
 		if (strpos($orderID, '-') !== false) {
@@ -392,6 +396,7 @@ class WooCommerce extends \Codeception\Module
 		}
 
 		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');
+		$I->waitForElementVisible('div.wrap form');
 		$I->submitForm(
 			'div.wrap > form',
 			[
@@ -413,7 +418,10 @@ class WooCommerce extends \Codeception\Module
 	{
 		// We perform the order status change by editing the Order as a WordPress Administrator would,
 		// so that WooCommerce triggers its actions and filters that our integration hooks into.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
 		if (strpos($orderID, '-') !== false) {
@@ -425,6 +433,7 @@ class WooCommerce extends \Codeception\Module
 		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');
 
 		// Refund the entire order.
+		$I->waitForElementVisible('button.refund-items');
 		$I->click('button.refund-items');
 		$I->waitForElementVisible('input#refund_amount');
 		$I->fillField('input#refund_amount', $amount);
@@ -448,7 +457,10 @@ class WooCommerce extends \Codeception\Module
 	{
 		// We perform the order status change by editing the Order as a WordPress Administrator would,
 		// so that WooCommerce triggers its actions and filters that our integration hooks into.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
 		if (strpos($orderID, '-') !== false) {
@@ -460,6 +472,7 @@ class WooCommerce extends \Codeception\Module
 		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');
 
 		// Change the email address.
+		$I->waitForElementVisible('a.edit_address:first-child');
 		$I->click('a.edit_address:first-child');
 		$I->waitForElementVisible('#_billing_email');
 
@@ -818,7 +831,10 @@ class WooCommerce extends \Codeception\Module
 	public function wooCommerceCreateManualOrder($I, $productID, $productName, $orderStatus, $paymentMethod)
 	{
 		// Login as Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// Define Email Address for this Manual Order.
 		$emailAddress = $I->generateEmailAddress();
@@ -834,6 +850,9 @@ class WooCommerce extends \Codeception\Module
 
 		// Load New Order screen.
 		$I->amOnAdminPage('post-new.php?post_type=shop_order');
+
+		// Wait for the New Order screen to load.
+		$I->waitForElementVisible('body.woocommerce_page_wc-orders');
 
 		// Check that no WooCommerce, PHP warnings or notices were output.
 		$I->checkNoWarningsAndNoticesOnScreen($I);
@@ -883,11 +902,10 @@ class WooCommerce extends \Codeception\Module
 	 */
 	public function wooCommerceOrderNoteExists($I, $orderID, $noteText)
 	{
-		// Logout.
-		$I->logOut();
-
-		// Login as Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
 		if (strpos($orderID, '-') !== false) {
@@ -897,6 +915,9 @@ class WooCommerce extends \Codeception\Module
 
 		// Load Edit Order screen.
 		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');
+
+		// Wait for the Order Notes to load.
+		$I->waitForElementVisible('#woocommerce-order-notes');
 
 		// Confirm note text exists.
 		$I->seeInSource($noteText);
@@ -913,8 +934,10 @@ class WooCommerce extends \Codeception\Module
 	 */
 	public function wooCommerceOrderNoteDoesNotExist($I, $orderID, $noteText)
 	{
-		// Login as Administrator.
-		$I->loginAsAdmin();
+		// Login as the Administrator, if we're not already logged in.
+		if ( ! $I->amLoggedInAsAdmin($I) ) {
+			$I->doLoginAsAdmin($I);
+		}
 
 		// If the Order ID contains dashes, it's prefixed by the Custom Order Numbers Plugin.
 		if (strpos($orderID, '-') !== false) {
@@ -924,6 +947,9 @@ class WooCommerce extends \Codeception\Module
 
 		// Load Edit Order screen.
 		$I->amOnAdminPage('post.php?post=' . $orderID . '&action=edit');
+
+		// Wait for the Order Notes to load.
+		$I->waitForElementVisible('#woocommerce-order-notes');
 
 		// Confirm note text does not exist.
 		$I->dontSeeInSource($noteText);


### PR DESCRIPTION
## Summary

[It seems that this chromedriver v134 bug](https://issues.chromium.org/issues/402796660) results in tests failing due to methods such as `click_button` return control to the test before fully completing.  There's also a lot of other repositories having similar issues with a [variety of test frameworks](https://github.com/teamcapybara/capybara/issues/2800).

Fixes tests by ensuring elements are fully loaded before attempting to perform the next step.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)