### PR TITLE
Custom Fields: Replace `Exclude Name from Billing & Shipping Addresses` with `Address Format` setting

### DIFF
--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -817,9 +817,6 @@ class CKWC_Integration extends WC_Integration {
 						'sync_past_orders_confirmation_message' => __( 'Do you want to send past WooCommerce Orders to Kit?', 'woocommerce-convertkit' ),
 					)
 				);
-
-				// Enqueue Select2 JS.
-				ckwc_select2_enqueue_scripts();
 				break;
 
 		}
@@ -852,15 +849,6 @@ class CKWC_Integration extends WC_Integration {
 			 */
 			case 'sync_past_orders':
 				wp_enqueue_style( 'ckwc-sync-past-orders', CKWC_PLUGIN_URL . 'resources/backend/css/sync-past-orders.css', array(), CKWC_PLUGIN_VERSION );
-				break;
-
-			/**
-			 * Settings Screen.
-			 */
-			case 'settings':
-			default:
-				// Enqueue Select2 CSS.
-				ckwc_select2_enqueue_styles();
 				break;
 
 		}

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -443,7 +443,7 @@ class CKWC_Integration extends WC_Integration {
 
 		$this->form_fields = array(
 			// Account name.
-			'account_name'                      => array(
+			'account_name'                  => array(
 				'title' => __( 'Account Name', 'woocommerce-convertkit' ),
 				'type'  => 'oauth_disconnect',
 				'label' => __( 'Disconnect', 'woocommerce-convertkit' ),
@@ -462,7 +462,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Enable/Disable entire integration.
-			'enabled'                           => array(
+			'enabled'                       => array(
 				'title'   => __( 'Enable/Disable', 'woocommerce-convertkit' ),
 				'type'    => 'checkbox',
 				'label'   => __( 'Enable Kit integration', 'woocommerce-convertkit' ),
@@ -470,7 +470,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Subscribe.
-			'event'                             => array(
+			'event'                         => array(
 				'title'       => __( 'Subscribe Event', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'pending',
@@ -508,7 +508,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'subscription'                      => array(
+			'subscription'                  => array(
 				'title'       => __( 'Subscription', 'woocommerce-convertkit' ),
 				'type'        => 'subscription',
 				'default'     => '',
@@ -517,7 +517,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'name_format'                       => array(
+			'name_format'                   => array(
 				'title'       => __( 'Name Format', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'first',
@@ -534,7 +534,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Custom Field Mappings.
-			'custom_field_last_name'            => array(
+			'custom_field_last_name'        => array(
 				'title'       => __( 'Send Last Name', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -543,7 +543,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_phone'                => array(
+			'custom_field_phone'            => array(
 				'title'       => __( 'Send Phone Number', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -552,7 +552,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_billing_address'      => array(
+			'custom_field_billing_address'  => array(
 				'title'       => __( 'Send Billing Address', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -561,7 +561,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_shipping_address'     => array(
+			'custom_field_shipping_address' => array(
 				'title'       => __( 'Send Shipping Address', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -570,16 +570,35 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_address_exclude_name' => array(
-				'title'       => __( 'Exclude Name from Billing & Shipping Addresses', 'woocommerce-convertkit' ),
-				'type'        => 'checkbox',
-				'default'     => 'no',
-				'description' => __( 'If enabled, removes the order\'s first name, last name and company name when storing the billing and shipping address above.', 'woocommerce-convertkit' ),
+			'custom_field_address_format'   => array(
+				'title'       => __( 'Address Format', 'woocommerce-convertkit' ),
+				'type'        => 'multiselect',
+				'default'     => array(
+					'name',
+					'company',
+					'address_1',
+					'address_2',
+					'city',
+					'state',
+					'postcode',
+				),
+				'description' => __( 'The format of the billing and shipping addresses to store in Kit.', 'woocommerce-convertkit' ),
+				'desc_tip'    => false,
+				'options'     => array(
+					'name' 	     => __( 'Name', 'woocommerce-convertkit' ),
+					'company'    => __( 'Company Name', 'woocommerce-convertkit' ),
+					'address_1'  => __( 'Address 1', 'woocommerce-convertkit' ),
+					'address_2'  => __( 'Address 2', 'woocommerce-convertkit' ),
+					'city'       => __( 'City', 'woocommerce-convertkit' ),
+					'state'      => __( 'State', 'woocommerce-convertkit' ),
+					'postcode'   => __( 'Postcode', 'woocommerce-convertkit' ),
+					'country'    => __( 'Country', 'woocommerce-convertkit' ),
+				),
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_payment_method'       => array(
+			'custom_field_payment_method'   => array(
 				'title'       => __( 'Send Payment Method', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -588,7 +607,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'custom_field_customer_note'        => array(
+			'custom_field_customer_note'    => array(
 				'title'       => __( 'Send Customer Note', 'woocommerce-convertkit' ),
 				'type'        => 'custom_field',
 				'default'     => '',
@@ -599,7 +618,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Subscribe: Display Opt In Checkbox Settings.
-			'display_opt_in'                    => array(
+			'display_opt_in'                => array(
 				'title'       => __( 'Opt-In Checkbox', 'woocommerce-convertkit' ),
 				'label'       => __( 'Display an opt-in checkbox on checkout', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
@@ -614,7 +633,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'opt_in_label'                      => array(
+			'opt_in_label'                  => array(
 				'title'       => __( 'Opt-In Checkbox: Label', 'woocommerce-convertkit' ),
 				'type'        => 'text',
 				'default'     => __( 'I want to subscribe to the newsletter', 'woocommerce-convertkit' ),
@@ -624,7 +643,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe display_opt_in',
 			),
-			'opt_in_status'                     => array(
+			'opt_in_status'                 => array(
 				'title'       => __( 'Opt-In Checkbox: Default Status', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'checked',
@@ -638,7 +657,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe display_opt_in',
 			),
-			'opt_in_location'                   => array(
+			'opt_in_location'               => array(
 				'title'       => __( 'Opt-In Checkbox: Display Location', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'billing',
@@ -654,7 +673,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Purchase Data.
-			'send_purchases'                    => array(
+			'send_purchases'                => array(
 				'title'       => __( 'Purchase Data', 'woocommerce-convertkit' ),
 				'label'       => __( 'Send purchase data to Kit.', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
@@ -669,7 +688,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe',
 			),
-			'send_purchases_event'              => array(
+			'send_purchases_event'          => array(
 				'title'       => __( 'Purchase Data Event', 'woocommerce-convertkit' ),
 				'type'        => 'select',
 				'default'     => 'processing',
@@ -700,7 +719,7 @@ class CKWC_Integration extends WC_Integration {
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
 				'class'       => 'enabled subscribe send_purchases',
 			),
-			'sync_past_orders'                  => array(
+			'sync_past_orders'              => array(
 				'title'    => __( 'Sync Past Orders', 'woocommerce-convertkit' ),
 				'label'    => __( 'Send old purchase data to Kit i.e. Orders that were created in WooCommerce prior to this Plugin being installed.', 'woocommerce-convertkit' ),
 				'type'     => 'sync_past_orders_button',
@@ -717,7 +736,7 @@ class CKWC_Integration extends WC_Integration {
 			),
 
 			// Debugging.
-			'debug'                             => array(
+			'debug'                         => array(
 				'title'       => __( 'Debug', 'woocommerce-convertkit' ),
 				'type'        => 'checkbox',
 				'label'       => __( 'Write data to a log file', 'woocommerce-convertkit' ),

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -585,14 +585,14 @@ class CKWC_Integration extends WC_Integration {
 				'description' => __( 'The format of the billing and shipping addresses to store in Kit.', 'woocommerce-convertkit' ),
 				'desc_tip'    => false,
 				'options'     => array(
-					'name' 	     => __( 'Name', 'woocommerce-convertkit' ),
-					'company'    => __( 'Company Name', 'woocommerce-convertkit' ),
-					'address_1'  => __( 'Address 1', 'woocommerce-convertkit' ),
-					'address_2'  => __( 'Address 2', 'woocommerce-convertkit' ),
-					'city'       => __( 'City', 'woocommerce-convertkit' ),
-					'state'      => __( 'State', 'woocommerce-convertkit' ),
-					'postcode'   => __( 'Postcode', 'woocommerce-convertkit' ),
-					'country'    => __( 'Country', 'woocommerce-convertkit' ),
+					'name'      => __( 'Name', 'woocommerce-convertkit' ),
+					'company'   => __( 'Company Name', 'woocommerce-convertkit' ),
+					'address_1' => __( 'Address 1', 'woocommerce-convertkit' ),
+					'address_2' => __( 'Address 2', 'woocommerce-convertkit' ),
+					'city'      => __( 'City', 'woocommerce-convertkit' ),
+					'state'     => __( 'State', 'woocommerce-convertkit' ),
+					'postcode'  => __( 'Postcode', 'woocommerce-convertkit' ),
+					'country'   => __( 'Country', 'woocommerce-convertkit' ),
 				),
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.

--- a/includes/class-ckwc-integration.php
+++ b/includes/class-ckwc-integration.php
@@ -596,7 +596,7 @@ class CKWC_Integration extends WC_Integration {
 				),
 
 				// The setting name that needs to be checked/enabled for this setting to display. Used by JS to toggle visibility.
-				'class'       => 'enabled subscribe',
+				'class'       => 'enabled subscribe wc-enhanced-select',
 			),
 			'custom_field_payment_method'   => array(
 				'title'       => __( 'Send Payment Method', 'woocommerce-convertkit' ),

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -1034,13 +1034,9 @@ class CKWC_Order {
 
 		$fields = array();
 
-		// If the name and company name should be excluded from the billing and shipping address
-		// fetched using get_formatted_billing_address() / get_formatted_shipping_address(),
-		// add filters now.
-		if ( $this->integration->get_option_bool( 'custom_field_address_exclude_name' ) ) {
-			add_filter( 'woocommerce_order_formatted_billing_address', array( $this, 'remove_name_from_address' ) );
-			add_filter( 'woocommerce_order_formatted_shipping_address', array( $this, 'remove_name_from_address' ) );
-		}
+		// Filter the billing and shipping address to only include the address parts specified in the integration settings.
+		add_filter( 'woocommerce_order_formatted_billing_address', array( $this, 'format_address' ) );
+		add_filter( 'woocommerce_order_formatted_shipping_address', array( $this, 'format_address' ) );
 
 		if ( $this->integration->get_option( 'custom_field_last_name' ) ) {
 			$fields[ $this->integration->get_option( 'custom_field_last_name' ) ] = $order->get_billing_last_name();
@@ -1061,13 +1057,9 @@ class CKWC_Order {
 			$fields[ $this->integration->get_option( 'custom_field_customer_note' ) ] = $order->get_customer_note();
 		}
 
-		// If the name and company name should be excluded from the billing and shipping address
-		// fetched using get_formatted_billing_address() / get_formatted_shipping_address(),
-		// remove filters now so these WooCommerce functions work correctly for other Plugins.
-		if ( $this->integration->get_option_bool( 'custom_field_address_exclude_name' ) ) {
-			remove_filter( 'woocommerce_order_formatted_billing_address', array( $this, 'remove_name_from_address' ) );
-			remove_filter( 'woocommerce_order_formatted_shipping_address', array( $this, 'remove_name_from_address' ) );
-		}
+		// Remove billing and shipping addressfilters now, so these WooCommerce functions work correctly for other Plugins.
+		remove_filter( 'woocommerce_order_formatted_billing_address', array( $this, 'format_address' ) );
+		remove_filter( 'woocommerce_order_formatted_shipping_address', array( $this, 'format_address' ) );
 
 		/**
 		 * Returns an array of ConvertKit Custom Field Key/Value pairs, with values
@@ -1088,17 +1080,31 @@ class CKWC_Order {
 	}
 
 	/**
-	 * Removes the first name, last name and company name from the WooCommerce Order address,
-	 * when calling WC_Order->get_formatted_billing_address() and WC_Order->get_formatted_shipping_address().
+	 * Removes the address parts from the WooCommerce Order address when calling WC_Order->get_formatted_billing_address()
+	 * and WC_Order->get_formatted_shipping_address(), based on the integration settings.
 	 *
-	 * @since   1.8.5
+	 * @since   1.9.5
 	 *
 	 * @param   array $address    Billing or Shipping Address.
 	 * @return  array
 	 */
-	public function remove_name_from_address( $address ) {
+	public function format_address( $address ) {
 
-		unset( $address['first_name'], $address['last_name'], $address['company_name'] );
+		// Get address fields to include.
+		$address_fields = $this->integration->get_option( 'custom_field_address_format' );
+
+		// If no address fields are specified, return the full address.
+		if ( empty( $address_fields ) ) {
+			return $address;
+		}
+
+		// Remove address fields that are not specified in the integration settings.
+		foreach ( $address as $key => $value ) {
+			if ( ! in_array( $key, $address_fields, true ) ) {
+				unset( $address[ $key ] );
+			}
+		}
+
 		return $address;
 
 	}

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -1037,6 +1037,7 @@ class CKWC_Order {
 		// Filter the billing and shipping address to only include the address parts specified in the integration settings.
 		add_filter( 'woocommerce_order_formatted_billing_address', array( $this, 'format_address' ) );
 		add_filter( 'woocommerce_order_formatted_shipping_address', array( $this, 'format_address' ) );
+		add_filter( 'woocommerce_formatted_address_force_country_display', array( $this, 'include_country_in_address_array' ) );
 
 		if ( $this->integration->get_option( 'custom_field_last_name' ) ) {
 			$fields[ $this->integration->get_option( 'custom_field_last_name' ) ] = $order->get_billing_last_name();
@@ -1060,6 +1061,7 @@ class CKWC_Order {
 		// Remove billing and shipping addressfilters now, so these WooCommerce functions work correctly for other Plugins.
 		remove_filter( 'woocommerce_order_formatted_billing_address', array( $this, 'format_address' ) );
 		remove_filter( 'woocommerce_order_formatted_shipping_address', array( $this, 'format_address' ) );
+		remove_filter( 'woocommerce_formatted_address_force_country_display', array( $this, 'include_country_in_address_array' ) );
 
 		/**
 		 * Returns an array of ConvertKit Custom Field Key/Value pairs, with values
@@ -1106,6 +1108,25 @@ class CKWC_Order {
 		}
 
 		return $address;
+
+	}
+
+	/**
+	 * Includes the country in the WooCommerce Order address array, overriding the
+	 * logic in WooCommerce's WC_Order->get_formatted_billing_address() which would
+	 * blank the Order's country if it matches the store's base country.
+	 *
+	 * This allows the country to be included in the Custom Field billing / shipping address
+	 * if configured when running the address through format_address().
+	 *
+	 * @since   1.9.5
+	 *
+	 * @param   bool $force_country_display  Whether to force the country to be displayed.
+	 * @return  bool
+	 */
+	public function include_country_in_address_array( $force_country_display ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+
+		return true;
 
 	}
 

--- a/includes/class-ckwc-order.php
+++ b/includes/class-ckwc-order.php
@@ -1100,7 +1100,7 @@ class CKWC_Order {
 
 		// Remove address fields that are not specified in the integration settings.
 		foreach ( $address as $key => $value ) {
-			if ( ! in_array( $key, $address_fields, true ) ) {
+			if ( ! in_array( $key, $address_fields, true ) ) { // @phpstan-ignore-line `get_option` can return an array, but WooCommerce's docblock is incorrect.
 				unset( $address[ $key ] );
 			}
 		}

--- a/includes/class-ckwc-setup.php
+++ b/includes/class-ckwc-setup.php
@@ -30,6 +30,13 @@ class CKWC_Setup {
 		}
 
 		/**
+		 * 1.9.5: Migrate `Exclude Name and Address` setting to `Address Format` setting.
+		 */
+		if ( ! $current_version || version_compare( $current_version, '1.9.5', '<' ) ) {
+			$this->migrate_exclude_name_and_address_setting_to_address_format();
+		}
+
+		/**
 		 * 1.8.0: Get Access token for API version 4.0 using a v3 API Key and Secret.
 		 */
 		if ( ! $current_version || version_compare( $current_version, '1.8.0', '<' ) ) {
@@ -42,14 +49,13 @@ class CKWC_Setup {
 	}
 
 	/**
-	 * 1.8.0: Fetch an Access Token, Refresh Token and Expiry for v4 API use
-	 * based on the Plugin setting's v3 API Key and Secret.
+	 * 1.9.5: Migrate `Exclude Name and Address` setting to `Address Format` setting.
 	 *
-	 * @since   1.8.0
+	 * @since   1.9.5
 	 */
-	private function maybe_get_access_token_by_api_key_and_secret() {
+	private function migrate_exclude_name_and_address_setting_to_address_format() {
 
-		// Bail if ConverKit for WooCommerce not active.
+		// Bail if Kit for WooCommerce not active.
 		if ( ! function_exists( 'WP_CKWC_Integration' ) ) {
 			return;
 		}
@@ -57,7 +63,39 @@ class CKWC_Setup {
 		// Load integration.
 		$integration = WP_CKWC_Integration();
 
-		// Bail if ConverKit for WooCommerce not active.
+		// Bail if Kit for WooCommerce not active.
+		if ( ! $integration ) {
+			return;
+		}
+
+		// Bail if `Exclude Name and Address` setting is not enabled.
+		if ( $integration->get_option( 'custom_field_address_exclude_name' ) !== 'yes' ) {
+			return;
+		}
+
+		// Update `Address Format` setting, not selecting Name and Company Name.
+		// Don't include country, as this was never included in Custom Field Billing / Shipping Addresses.
+		$integration->update_option( 'custom_field_address_format', array( 'address_1', 'address_2', 'city', 'state', 'postcode' ) );
+
+	}
+
+	/**
+	 * 1.8.0: Fetch an Access Token, Refresh Token and Expiry for v4 API use
+	 * based on the Plugin setting's v3 API Key and Secret.
+	 *
+	 * @since   1.8.0
+	 */
+	private function maybe_get_access_token_by_api_key_and_secret() {
+
+		// Bail if Kit for WooCommerce not active.
+		if ( ! function_exists( 'WP_CKWC_Integration' ) ) {
+			return;
+		}
+
+		// Load integration.
+		$integration = WP_CKWC_Integration();
+
+		// Bail if Kit for WooCommerce not active.
 		if ( ! $integration ) {
 			return;
 		}

--- a/tests/EndToEnd/general/UpgradePathsCest.php
+++ b/tests/EndToEnd/general/UpgradePathsCest.php
@@ -74,6 +74,39 @@ class UpgradePathsCest
 	}
 
 	/**
+	 * Test that the `Exclude Name and Address` setting is migrated to the `Address Format` setting
+	 * when upgrading to 1.9.5 or later.
+	 *
+	 * @since   1.9.5
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testMigrateExcludeNameAndAddressSettingToAddressFormat(EndToEndTester $I)
+	{
+		// Setup Plugin's settings with the `Exclude Name and Address` setting enabled.
+		$I->haveOptionInDatabase(
+			'woocommerce_ckwc_settings',
+			[
+				'enabled'                           => 'yes',
+				'access_token'                      => $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'],
+				'refresh_token'                     => $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'],
+				'custom_field_address_exclude_name' => 'yes',
+			]
+		);
+
+		// Define an installation version older than 1.9.5.
+		$I->haveOptionInDatabase('ckwc_version', '1.4.0');
+
+		// Activate the Plugin, as if we just upgraded to 1.8.0 or higher.
+		$I->activateWooCommerceAndConvertKitPlugins($I);
+
+		// Confirm the options table now contains the address format without Name and Company Name.
+		$settings = $I->grabOptionFromDatabase('woocommerce_ckwc_settings');
+		$I->assertArrayHasKey('custom_field_address_format', $settings);
+		$I->assertEquals(array( 'address_1', 'address_2', 'city', 'state', 'postcode' ), $settings['custom_field_address_format']);
+	}
+
+	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.
 	 * We don't use _after, as this would provide a screenshot of the Plugin
 	 * deactivation and not the true test error.

--- a/tests/EndToEnd/purchase-data/PurchaseDataCest.php
+++ b/tests/EndToEnd/purchase-data/PurchaseDataCest.php
@@ -138,6 +138,9 @@ class PurchaseDataCest
 	 */
 	public function testSendPurchaseDataWithCustomFieldsAndExcludeNameFromAddressOnSimpleProductCheckout(EndToEndTester $I)
 	{
+		// Define the address fields to include in the custom field data.
+		$addressFields = array( 'address_1', 'city', 'state', 'postcode', 'country' );
+
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
@@ -146,7 +149,7 @@ class PurchaseDataCest
 				'check_opt_in'              => false,
 				'send_purchase_data'        => true,
 				'custom_fields'             => true,
-				'exclude_name_from_address' => true,
+				'address_fields' 			=> $addressFields,
 			]
 		);
 
@@ -165,7 +168,7 @@ class PurchaseDataCest
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
-		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+		$I->apiCustomFieldDataIsValid($I, $subscriber, $addressFields );
 
 		// Check that the Order's Notes include a note from the Plugin confirming the custom field data was added to ConvertKit.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], '[Kit] Purchase Data: Custom Fields sent successfully: Subscriber ID [' . $subscriber['id'] . ']');

--- a/tests/EndToEnd/purchase-data/PurchaseDataCest.php
+++ b/tests/EndToEnd/purchase-data/PurchaseDataCest.php
@@ -145,11 +145,11 @@ class PurchaseDataCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'display_opt_in'            => false,
-				'check_opt_in'              => false,
-				'send_purchase_data'        => true,
-				'custom_fields'             => true,
-				'address_fields' 			=> $addressFields,
+				'display_opt_in'     => false,
+				'check_opt_in'       => false,
+				'send_purchase_data' => true,
+				'custom_fields'      => true,
+				'address_fields'     => $addressFields,
 			]
 		);
 

--- a/tests/EndToEnd/settings/SettingCustomFieldsCest.php
+++ b/tests/EndToEnd/settings/SettingCustomFieldsCest.php
@@ -58,7 +58,7 @@ class SettingCustomFieldsCest
 		$I->selectOption('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
 		$I->selectOption('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
 		$I->selectOption('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
-		$I->checkOption('#woocommerce_ckwc_custom_field_address_exclude_name');
+		$I->selectOption('#woocommerce_ckwc_custom_field_address_format', [ 'Name', 'Company Name', 'Address 1', 'City', 'State', 'Postcode', 'Country' ]);
 		$I->selectOption('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
 		$I->selectOption('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
 
@@ -73,7 +73,13 @@ class SettingCustomFieldsCest
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_phone', 'Phone Number');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_billing_address', 'Billing Address');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_shipping_address', 'Shipping Address');
-		$I->seeCheckboxIsChecked('#woocommerce_ckwc_custom_field_address_exclude_name');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_address_format', 'Name');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_address_format', 'Company Name');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_address_format', 'Address 1');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_address_format', 'City');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_address_format', 'State');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_address_format', 'Postcode');
+		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_address_format', 'Country');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_payment_method', 'Payment Method');
 		$I->seeOptionIsSelected('#woocommerce_ckwc_custom_field_customer_note', 'Notes');
 	}

--- a/tests/EndToEnd/settings/SettingOAuthCest.php
+++ b/tests/EndToEnd/settings/SettingOAuthCest.php
@@ -38,8 +38,6 @@ class SettingOAuthCest
 
 		// Confirm CSS and JS is output by the Plugin.
 		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/settings.css', 'ckwc-settings-css' );
-		$I->seeCSSEnqueued($I, 'convertkit-woocommerce/resources/backend/css/select2.css', 'ckwc-admin-select2-css' );
-		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/select2.js' );
 		$I->seeJSEnqueued($I, 'convertkit-woocommerce/resources/backend/js/integration.js' );
 
 		// Confirm no option is displayed to save changes, as the Plugin isn't authenticated.

--- a/tests/EndToEnd/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
@@ -221,13 +221,13 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'display_opt_in'            => true,
-				'check_opt_in'              => true,
-				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
-				'subscription_event'        => 'processing',
-				'custom_fields'             => true,
-				'address_fields' 			=> $addressFields,
-				'use_legacy_checkout'       => false,
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+				'custom_fields'            => true,
+				'address_fields'           => $addressFields,
+				'use_legacy_checkout'      => false,
 			]
 		);
 

--- a/tests/EndToEnd/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
@@ -214,6 +214,9 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 	 */
 	public function testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct(EndToEndTester $I)
 	{
+		// Define the address fields to include in the custom field data.
+		$addressFields = array( 'address_1', 'city', 'state', 'postcode', 'country' );
+
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
@@ -223,7 +226,7 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'processing',
 				'custom_fields'             => true,
-				'exclude_name_from_address' => true,
+				'address_fields' 			=> $addressFields,
 				'use_legacy_checkout'       => false,
 			]
 		);
@@ -241,7 +244,7 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
-		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+		$I->apiCustomFieldDataIsValid($I, $subscriber, $addressFields );
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);

--- a/tests/EndToEnd/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -282,12 +282,12 @@ class SubscribeOnOrderCompletedEventCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'display_opt_in'            => true,
-				'check_opt_in'              => true,
-				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
-				'subscription_event'        => 'completed',
-				'custom_fields'             => true,
-				'address_fields' 			=> $addressFields,
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'completed',
+				'custom_fields'            => true,
+				'address_fields'           => $addressFields,
 			]
 		);
 

--- a/tests/EndToEnd/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -275,6 +275,9 @@ class SubscribeOnOrderCompletedEventCest
 	 */
 	public function testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct(EndToEndTester $I)
 	{
+		// Define the address fields to include in the custom field data.
+		$addressFields = array( 'address_1', 'city', 'state', 'postcode', 'country' );
+
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
@@ -284,7 +287,7 @@ class SubscribeOnOrderCompletedEventCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'completed',
 				'custom_fields'             => true,
-				'exclude_name_from_address' => true,
+				'address_fields' 			=> $addressFields,
 			]
 		);
 
@@ -299,7 +302,7 @@ class SubscribeOnOrderCompletedEventCest
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
-		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+		$I->apiCustomFieldDataIsValid($I, $subscriber, $addressFields );
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);

--- a/tests/EndToEnd/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -192,6 +192,9 @@ class SubscribeOnOrderPendingPaymentEventCest
 	 */
 	public function testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct(EndToEndTester $I)
 	{
+		// Define the address fields to include in the custom field data.
+		$addressFields = array( 'address_1', 'city', 'state', 'postcode', 'country' );
+
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
@@ -201,7 +204,7 @@ class SubscribeOnOrderPendingPaymentEventCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'pending',
 				'custom_fields'             => true,
-				'exclude_name_from_address' => true,
+				'address_fields' 			=> $addressFields,
 			]
 		);
 
@@ -218,7 +221,7 @@ class SubscribeOnOrderPendingPaymentEventCest
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
-		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+		$I->apiCustomFieldDataIsValid($I, $subscriber, $addressFields );
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);

--- a/tests/EndToEnd/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -199,12 +199,12 @@ class SubscribeOnOrderPendingPaymentEventCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'display_opt_in'            => true,
-				'check_opt_in'              => true,
-				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
-				'subscription_event'        => 'pending',
-				'custom_fields'             => true,
-				'address_fields' 			=> $addressFields,
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'pending',
+				'custom_fields'            => true,
+				'address_fields'           => $addressFields,
 			]
 		);
 

--- a/tests/EndToEnd/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -210,6 +210,9 @@ class SubscribeOnOrderProcessingEventCest
 	 */
 	public function testOptInWhenCheckedWithFormCustomFieldsAndExcludeNameFromAddressOnSimpleProduct(EndToEndTester $I)
 	{
+		// Define the address fields to include in the custom field data.
+		$addressFields = array( 'address_1', 'city', 'state', 'postcode', 'country' );
+
 		// Create Product and Checkout for this test.
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
@@ -219,7 +222,7 @@ class SubscribeOnOrderProcessingEventCest
 				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'        => 'processing',
 				'custom_fields'             => true,
-				'exclude_name_from_address' => true,
+				'address_fields' 			=> $addressFields,
 			]
 		);
 
@@ -228,7 +231,7 @@ class SubscribeOnOrderProcessingEventCest
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
-		$I->apiCustomFieldDataIsValid($I, $subscriber, true);
+		$I->apiCustomFieldDataIsValid($I, $subscriber, $addressFields );
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(

--- a/tests/EndToEnd/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -217,12 +217,12 @@ class SubscribeOnOrderProcessingEventCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
 			$I,
 			[
-				'display_opt_in'            => true,
-				'check_opt_in'              => true,
-				'plugin_form_tag_sequence'  => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
-				'subscription_event'        => 'processing',
-				'custom_fields'             => true,
-				'address_fields' 			=> $addressFields,
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+				'custom_fields'            => true,
+				'address_fields'           => $addressFields,
 			]
 		);
 

--- a/tests/Support/Helper/KitAPI.php
+++ b/tests/Support/Helper/KitAPI.php
@@ -258,13 +258,35 @@ class KitAPI extends \Codeception\Module
 	 *
 	 * @param   EndToEndTester $I                         EndToEndTester.
 	 * @param   array          $subscriber                Subscriber from API.
-	 * @param   bool           $excludeNameFromAddress    Exclude name from billing address.
+	 * @param   bool|array     $addressFields    	  	  Expected fields in billing address (false = all fields).
 	 */
-	public function apiCustomFieldDataIsValid($I, $subscriber, $excludeNameFromAddress = false)
+	public function apiCustomFieldDataIsValid($I, $subscriber, $addressFields = false)
 	{
+		// The default address data used for all tests.
+		$address = array(
+			'first_name' => 'First',
+			'last_name' => 'Last',
+			'company' => 'Company',
+			'address_1' => 'Address Line 1',
+			'address_2' => 'Address Line 2',
+			'city' => 'City',
+			'state' => 'CA',
+			'postcode' => '12345',
+			'country' => 'United States (US)',
+		);
+
+		// If no address fields are specified, build the expected address based on the integration's default setting.
+		if ( ! $addressFields ) {
+			$addressFields = array( 'name', 'address_1', 'city', 'state', 'postcode', 'country' );
+		}
+		
+		// Build address array.
+		$address = array_intersect_key( $address, array_flip( $addressFields ) );
+
+		// Check the subscriber's custom field data is valid.
 		$I->assertEquals($subscriber['fields']['last_name'], 'Last');
 		$I->assertEquals($subscriber['fields']['phone_number'], '6159684594');
-		$I->assertEquals($subscriber['fields']['billing_address'], ( $excludeNameFromAddress ? 'Address Line 1, City, CA 12345' : 'First Last, Address Line 1, City, CA 12345' ));
+		$I->assertEquals($subscriber['fields']['billing_address'], implode(', ', $address));
 		$I->assertEquals($subscriber['fields']['payment_method'], 'cod');
 		$I->assertEquals($subscriber['fields']['notes'], 'Notes');
 	}

--- a/tests/Support/Helper/KitAPI.php
+++ b/tests/Support/Helper/KitAPI.php
@@ -258,35 +258,39 @@ class KitAPI extends \Codeception\Module
 	 *
 	 * @param   EndToEndTester $I                         EndToEndTester.
 	 * @param   array          $subscriber                Subscriber from API.
-	 * @param   bool|array     $addressFields    	  	  Expected fields in billing address (false = all fields).
+	 * @param   bool|array     $addressFields             Expected fields in billing address (false = all fields).
 	 */
 	public function apiCustomFieldDataIsValid($I, $subscriber, $addressFields = false)
 	{
 		// The default address data used for all tests.
 		$address = array(
 			'first_name' => 'First',
-			'last_name' => 'Last',
-			'company' => 'Company',
-			'address_1' => 'Address Line 1',
-			'address_2' => 'Address Line 2',
-			'city' => 'City',
-			'state' => 'CA',
-			'postcode' => '12345',
-			'country' => 'United States (US)',
+			'last_name'  => 'Last',
+			'company'    => 'Company',
+			'address_1'  => 'Address Line 1',
+			'address_2'  => 'Address Line 2',
+			'city'       => 'City',
+			'state'      => 'CA',
+			'postcode'   => '12345',
+			'country'    => 'United States (US)',
 		);
 
 		// If no address fields are specified, build the expected address based on the integration's default setting.
 		if ( ! $addressFields ) {
 			$addressFields = array( 'name', 'address_1', 'city', 'state', 'postcode', 'country' );
 		}
-		
+
 		// Build address array.
 		$address = array_intersect_key( $address, array_flip( $addressFields ) );
+
+		// WooCommerce has no comma between the state and postcode on addresses, so remove it.
+		$addressString = implode(', ', $address);
+		$addressString = str_replace('CA, 12345', 'CA 12345', $addressString);
 
 		// Check the subscriber's custom field data is valid.
 		$I->assertEquals($subscriber['fields']['last_name'], 'Last');
 		$I->assertEquals($subscriber['fields']['phone_number'], '6159684594');
-		$I->assertEquals($subscriber['fields']['billing_address'], implode(', ', $address));
+		$I->assertEquals($subscriber['fields']['billing_address'], $addressString);
 		$I->assertEquals($subscriber['fields']['payment_method'], 'cod');
 		$I->assertEquals($subscriber['fields']['notes'], 'Notes');
 	}

--- a/tests/Support/Helper/Plugin.php
+++ b/tests/Support/Helper/Plugin.php
@@ -99,7 +99,7 @@ class Plugin extends \Codeception\Module
 	 * @param   bool           $mapCustomFields        Map Order data to Custom Fields.
 	 * @param   bool           $displayOptIn           Display Opt-In Checkbox.
 	 * @param   bool           $sendPurchaseDataEvent  Send Purchase Data to ConvertKit on Order Event.
-	 * @param   bool           $excludeNameFromAddress Exclude name from billing and shipping addresses.
+	 * @param   bool|array     $addressFields 		   Address fields to include in the custom field data (false = all address fields).
 	 */
 	public function setupConvertKitPlugin(
 		$I,
@@ -111,7 +111,7 @@ class Plugin extends \Codeception\Module
 		$mapCustomFields = false,
 		$displayOptIn = false,
 		$sendPurchaseDataEvent = false,
-		$excludeNameFromAddress = false
+		$addressFields = false
 	) {
 		// Define Plugin's settings.
 		$I->haveOptionInDatabase(
@@ -129,10 +129,10 @@ class Plugin extends \Codeception\Module
 				'custom_field_phone'                => ( $mapCustomFields ? 'phone_number' : '' ),
 				'custom_field_billing_address'      => ( $mapCustomFields ? 'billing_address' : '' ),
 				'custom_field_shipping_address'     => ( $mapCustomFields ? 'shipping_address' : '' ),
+				'custom_field_address_format'       => ( $addressFields ? $addressFields : array( 'name', 'address_1', 'address_2', 'city', 'state', 'postcode', 'country' ) ),
 				'custom_field_payment_method'       => ( $mapCustomFields ? 'payment_method' : '' ),
 				'custom_field_customer_note'        => ( $mapCustomFields ? 'notes' : '' ),
-				'custom_field_address_exclude_name' => ( $excludeNameFromAddress ? 'yes' : 'no' ),
-
+				
 				// Opt-In Checkbox.
 				'display_opt_in'                    => ( $displayOptIn ? 'yes' : 'no' ),
 				'opt_in_label'                      => 'I want to subscribe to the newsletter',

--- a/tests/Support/Helper/Plugin.php
+++ b/tests/Support/Helper/Plugin.php
@@ -99,7 +99,7 @@ class Plugin extends \Codeception\Module
 	 * @param   bool           $mapCustomFields        Map Order data to Custom Fields.
 	 * @param   bool           $displayOptIn           Display Opt-In Checkbox.
 	 * @param   bool           $sendPurchaseDataEvent  Send Purchase Data to ConvertKit on Order Event.
-	 * @param   bool|array     $addressFields 		   Address fields to include in the custom field data (false = all address fields).
+	 * @param   bool|array     $addressFields          Address fields to include in the custom field data (false = all address fields).
 	 */
 	public function setupConvertKitPlugin(
 		$I,
@@ -117,34 +117,34 @@ class Plugin extends \Codeception\Module
 		$I->haveOptionInDatabase(
 			'woocommerce_ckwc_settings',
 			[
-				'enabled'                           => 'yes',
-				'access_token'                      => ( $accessToken !== false ? $accessToken : $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'] ),
-				'refresh_token'                     => ( $refreshToken !== false ? $refreshToken : $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'] ),
-				'event'                             => $subscriptionEvent,
-				'subscription'                      => ( $subscription ? $subscription : '' ),
-				'name_format'                       => $nameFormat,
+				'enabled'                       => 'yes',
+				'access_token'                  => ( $accessToken !== false ? $accessToken : $_ENV['CONVERTKIT_OAUTH_ACCESS_TOKEN'] ),
+				'refresh_token'                 => ( $refreshToken !== false ? $refreshToken : $_ENV['CONVERTKIT_OAUTH_REFRESH_TOKEN'] ),
+				'event'                         => $subscriptionEvent,
+				'subscription'                  => ( $subscription ? $subscription : '' ),
+				'name_format'                   => $nameFormat,
 
 				// Custom Field mappings.
-				'custom_field_last_name'            => ( $mapCustomFields ? 'last_name' : '' ),
-				'custom_field_phone'                => ( $mapCustomFields ? 'phone_number' : '' ),
-				'custom_field_billing_address'      => ( $mapCustomFields ? 'billing_address' : '' ),
-				'custom_field_shipping_address'     => ( $mapCustomFields ? 'shipping_address' : '' ),
-				'custom_field_address_format'       => ( $addressFields ? $addressFields : array( 'name', 'address_1', 'address_2', 'city', 'state', 'postcode', 'country' ) ),
-				'custom_field_payment_method'       => ( $mapCustomFields ? 'payment_method' : '' ),
-				'custom_field_customer_note'        => ( $mapCustomFields ? 'notes' : '' ),
-				
+				'custom_field_last_name'        => ( $mapCustomFields ? 'last_name' : '' ),
+				'custom_field_phone'            => ( $mapCustomFields ? 'phone_number' : '' ),
+				'custom_field_billing_address'  => ( $mapCustomFields ? 'billing_address' : '' ),
+				'custom_field_shipping_address' => ( $mapCustomFields ? 'shipping_address' : '' ),
+				'custom_field_address_format'   => ( $addressFields ? $addressFields : array( 'name', 'address_1', 'address_2', 'city', 'state', 'postcode', 'country' ) ),
+				'custom_field_payment_method'   => ( $mapCustomFields ? 'payment_method' : '' ),
+				'custom_field_customer_note'    => ( $mapCustomFields ? 'notes' : '' ),
+
 				// Opt-In Checkbox.
-				'display_opt_in'                    => ( $displayOptIn ? 'yes' : 'no' ),
-				'opt_in_label'                      => 'I want to subscribe to the newsletter',
-				'opt_in_status'                     => 'checked',
-				'opt_in_location'                   => 'billing',
+				'display_opt_in'                => ( $displayOptIn ? 'yes' : 'no' ),
+				'opt_in_label'                  => 'I want to subscribe to the newsletter',
+				'opt_in_status'                 => 'checked',
+				'opt_in_location'               => 'billing',
 
 				// Purchase Data.
-				'send_purchases'                    => ( $sendPurchaseDataEvent ? 'yes' : 'no' ),
-				'send_purchases_event'              => ( $sendPurchaseDataEvent ? $sendPurchaseDataEvent : '' ),
+				'send_purchases'                => ( $sendPurchaseDataEvent ? 'yes' : 'no' ),
+				'send_purchases_event'          => ( $sendPurchaseDataEvent ? $sendPurchaseDataEvent : '' ),
 
 				// Debug.
-				'debug'                             => 'yes',
+				'debug'                         => 'yes',
 			]
 		);
 	}

--- a/tests/Support/Helper/WooCommerce.php
+++ b/tests/Support/Helper/WooCommerce.php
@@ -241,7 +241,7 @@ class WooCommerce extends \Codeception\Module
 			'send_purchase_data'        => false,
 			'product_form_tag_sequence' => false,
 			'custom_fields'             => false,
-			'exclude_name_from_address' => false,
+			'address_fields' 			=> false,
 			'name_format'               => 'first',
 			'coupon_form_tag_sequence'  => false,
 			'use_legacy_checkout'       => true,
@@ -265,7 +265,7 @@ class WooCommerce extends \Codeception\Module
 			$options['custom_fields'],
 			$options['display_opt_in'],
 			( ( $options['send_purchase_data'] === true ) ? 'processing' : $options['send_purchase_data'] ),
-			$options['exclude_name_from_address']
+			$options['address_fields']
 		);
 
 		// Create Product.

--- a/tests/Support/Helper/WooCommerce.php
+++ b/tests/Support/Helper/WooCommerce.php
@@ -241,7 +241,7 @@ class WooCommerce extends \Codeception\Module
 			'send_purchase_data'        => false,
 			'product_form_tag_sequence' => false,
 			'custom_fields'             => false,
-			'address_fields' 			=> false,
+			'address_fields'            => false,
 			'name_format'               => 'first',
 			'coupon_form_tag_sequence'  => false,
 			'use_legacy_checkout'       => true,

--- a/woocommerce-convertkit.php
+++ b/woocommerce-convertkit.php
@@ -9,13 +9,13 @@
  * Plugin Name: Kit (formerly ConvertKit) for WooCommerce
  * Plugin URI:  https://www.kit.com
  * Description: Integrates WooCommerce with Kit, allowing customers to be automatically sent to your Kit account.
- * Version: 1.9.4
+ * Version: 1.9.5
  * Author: Kit
  * Author URI: https://www.kit.com
  * Text Domain: woocommerce-convertkit
  *
  * WC requires at least: 3.0
- * WC tested up to: 9.6.1
+ * WC tested up to: 9.8.0
  */
 
 // Bail if Plugin is already loaded.
@@ -28,7 +28,7 @@ define( 'CKWC_PLUGIN_NAME', 'ConvertKitWooCommerce' ); // Used for user-agent in
 define( 'CKWC_PLUGIN_FILE', plugin_basename( __FILE__ ) );
 define( 'CKWC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CKWC_PLUGIN_PATH', __DIR__ );
-define( 'CKWC_PLUGIN_VERSION', '1.9.4' );
+define( 'CKWC_PLUGIN_VERSION', '1.9.5' );
 define( 'CKWC_OAUTH_CLIENT_ID', 'L0kyADsB3WP5zO5MvUpXQU64gIntQg9BBAIme17r_7A' );
 define( 'CKWC_OAUTH_CLIENT_REDIRECT_URI', 'https://app.kit.com/wordpress/redirect' );
 


### PR DESCRIPTION
## Summary

WooCommerce 9.8.0 now includes the country name by default when fetching an Order's address using `get_formatted_billing_address` and `get_formatted_shipping_address` methods, which resulted in tests breaking:

![Screenshot 2025-04-11 at 10 44 39](https://github.com/user-attachments/assets/579900be-2689-48c8-a150-164d221ef003)

Creators will expect the address data in their subscriber's custom fields to remain consistent. Rather than add another exclusion field ([as done for the `Exclude Name from Billing & Shipping Addresses` setting](https://github.com/Kit/convertkit-woocommerce/pull/193)), this PR adds a new `Address Format` setting, allowing creators to choose the precise address data to include in the subscriber's billing and shipping custom fields:

![Screenshot 2025-04-11 at 10 33 51](https://github.com/user-attachments/assets/1d30b570-3bd0-4da7-9683-e718d2cd60df)

By default, this is configured to include the company name, address, city, state and postcode, to match current behaviour.

For creators upgrading who have previously enabled the `Exclude Name from Billing & Shipping Addresses` setting, the new `Address Format` setting will include the address, city, state and postcode, again to match current behaviour.

## Testing

- `testMigrateExcludeNameAndAddressSettingToAddressFormat`: Test that the `Exclude Name from Billing & Shipping Addresses` setting is honored on upgrade, with the `Address Format` configured to exclude the name and company name.
- Purchase Data Custom Field tests updated to confirm address format is correct when e.g. the name is not selected in the `Address Format` setting.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)