### PR TITLE
Add `devcontainer` configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,73 @@
+{
+    "name": "WordPress Codespace",
+    "image": "ghcr.io/automattic/vip-codespaces/alpine-base:latest",
+    "overrideCommand": false,
+    "forwardPorts": [80, 81, 8025],
+    "portsAttributes": {
+        "80": {
+            "label": "Application",
+            "onAutoForward": "notify",
+            "elevateIfNeeded": true
+        },
+        "81": {
+            "label": "phpMyAdmin",
+            "onAutoForward": "notify",
+            "elevateIfNeeded": true
+        },
+        "3306": {
+            "label": "MySQL",
+            "onAutoForward": "ignore"
+        },
+        "9000": {
+            "label": "php-fpm",
+            "onAutoForward": "ignore"
+        },
+        "9003": {
+            "label": "Xdebug Client Port",
+            "onAutoForward": "notify"
+        }
+    },
+    "features": {
+        "ghcr.io/automattic/vip-codespaces/base:latest": {},
+        "ghcr.io/automattic/vip-codespaces/nginx:latest": {},
+        "ghcr.io/automattic/vip-codespaces/php:latest": {
+            "version": "8.2",
+            "composer": true
+        },
+        "ghcr.io/automattic/vip-codespaces/mariadb:latest": {
+            // Set to false to prevent the database content from persisting between rebuilds.
+            "installDatabaseToWorkspaces": true
+        },
+        "ghcr.io/automattic/vip-codespaces/wordpress:latest": {
+            // WordPress version: Accepts 'latest', 'nightly', or a version number.
+            "version": "latest",
+            // Set to false to prevent wp-content/uploads content from persisting between rebuilds.
+            "moveUploadsToWorkspaces": false,
+            // Set to true to create the environment as a WordPress multisite.
+            "multisite": false,
+            // GitHub Codespaces only supports the subdirectory network type for multisite; subdomain cannot be used.
+            "multisiteStyle": "subdirectory"
+        },
+        "ghcr.io/automattic/vip-codespaces/wp-cli:latest": {
+            // Set to true to enable nightly builds of WP-CLI.
+            "nightly": false
+        },
+        "ghcr.io/automattic/vip-codespaces/dev-tools:latest": {},
+        "ghcr.io/automattic/vip-codespaces/phpmyadmin:latest": {
+            // Set to false to disable phpMyAdmin.
+            "enabled": true
+        },
+        "ghcr.io/automattic/vip-codespaces/xdebug:latest": {
+            // Set to true to enable Xdebug.
+            // This setting can also be updated with CLI commands in the terminal.
+            "enabled": true,
+            // Set Xdebug mode. Accepted value options are listed here: https://xdebug.org/docs/all_settings#mode
+            "mode": "debug"
+        },
+        "ghcr.io/automattic/vip-codespaces/ssh:latest": {
+            // Set to true to enable an SSH server for the Codespaces environment.
+            "enabled": true
+        }
+    },
+    "postCreateCommand": "bash ./.devcontainer/post-create.sh"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -13,5 +13,6 @@ ln -s /workspaces/convertkit-woocommerce /wp/wp-content/plugins/convertkit-for-w
 cd /wp/wp-content/plugins/convertkit-for-woocommerce
 composer update
 
-# Activate Plugin
+# Activate Plugins
 wp plugin activate convertkit-for-woocommerce
+wp plugin activate woocommerce

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,7 +7,7 @@ wp plugin install classic-editor woocommerce
 wp theme install twentytwentyfive
 
 # Symlink Plugin
-ln -s /workspaces/convertkit-for-woocommerce /wp/wp-content/plugins/convertkit-for-woocommerce
+ln -s /workspaces/convertkit-woocommerce /wp/wp-content/plugins/convertkit-for-woocommerce
 
 # Run Composer in Plugin Directory to build
 cd /wp/wp-content/plugins/convertkit-for-woocommerce

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Install Free Third Party WordPress Plugins 
+wp plugin install classic-editor woocommerce
+
+# Install Default WordPress Theme
+wp theme install twentytwentyfive
+
+# Symlink Plugin
+ln -s /workspaces/convertkit-for-woocommerce /wp/wp-content/plugins/convertkit-for-woocommerce
+
+# Run Composer in Plugin Directory to build
+cd /wp/wp-content/plugins/convertkit-for-woocommerce
+composer update
+
+# Activate Plugin
+wp plugin activate convertkit-for-woocommerce

--- a/phpstan-dev.neon
+++ b/phpstan-dev.neon
@@ -1,0 +1,35 @@
+# PHPStan configuration for Dev Containers
+
+# Include PHPStan for WordPress configuration.
+includes:
+    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+# Parameters
+parameters:
+    # Paths to scan
+    # This should comprise of the base Plugin PHP file, plus directories that contain Plugin PHP files
+    paths:
+        - woocommerce-convertkit.php
+        - admin/
+        - includes/
+
+    # Files that include Plugin-specific PHP constants
+    bootstrapFiles:
+        - woocommerce-convertkit.php
+
+    # Location of WordPress Plugins for PHPStan to scan, building symbols.
+    scanDirectories:
+        - /wp/wp-content/plugins
+
+    # Location of constants, Kit helper functions and Kit WordPress Libraries for PHPStan to scan, building symbols.
+    scanFiles:
+        - /wp/wp-config.php
+
+    # Should not need to edit anything below here
+    # Rule Level: https://phpstan.org/user-guide/rule-levels
+    level: 5
+
+    # Ignore the following errors, as PHPStan and PHPStan for WordPress haven't registered symbols for them yet,
+    # so they're false positives.
+    ignoreErrors:
+        - '#Call to an undefined method WC_Order_Item::get_product\(\).#'


### PR DESCRIPTION
## Summary

Adds a `devcontainer.json` configuration to facilitate running a dev container locally or in GitHub Codespaces, using [WPVIP's configuration](https://docs.wpvip.com/local-development/github-codespaces/), which provides a ready made nginx, PHP, MySQL and WordPress setup.

Codespace example:
https://fictional-barnacle-7v6rg5pjqq3wxxj-80.app.github.dev
https://fictional-barnacle-7v6rg5pjqq3wxxj-80.app.github.dev/wp-admin/

- User: vipgo
- Pass: password

![Screenshot 2025-04-21 at 12 25 31](https://github.com/user-attachments/assets/f7cdd94d-cfd0-4dc9-b0b5-719439826ff8)

![Screenshot 2025-04-21 at 12 25 16](https://github.com/user-attachments/assets/c913d4d0-2b09-4109-b727-e4bebf443690)

![Screenshot 2025-04-21 at 12 24 13](https://github.com/user-attachments/assets/3efac49f-20e0-4f70-a3e9-9f9746628dfa)

Codeception (for end to end testing) isn't yet configured, as this requires chromedriver to run in a separate process.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)