### PR TITLE
Fix `build.sh`

### DIFF
--- a/.scripts/build.sh
+++ b/.scripts/build.sh
@@ -12,7 +12,7 @@ rm -rf vendor
 composer install --no-dev
 
 # Build ZIP file, excluding non-Plugin files
-rm convertkit-for-woocommerce.zip
+[ -e convertkit-for-woocommerce.zip ] && rm convertkit-for-woocommerce.zip
 zip -r convertkit-for-woocommerce.zip . \
 -x "*.git*" \
 -x ".devcontainer/*" \

--- a/.scripts/build.sh
+++ b/.scripts/build.sh
@@ -4,6 +4,39 @@ php create-actions-filters-docs.php
 # Generate .pot file
 php -n $(which wp) i18n make-pot ../ ../languages/woocommerce-convertkit.pot
 
-# Build ZIP file
-rm ../convertkit-for-woocommerce.zip
-cd .. && zip -r convertkit-for-woocommerce.zip . -x "*.git*" -x ".scripts/*" -x ".wordpress-org/*" -x "tests/*" -x "vendor/*" -x "*.distignore" -x "*.env.*" -x "*codeception.*" -x "composer.json" -x "composer.lock" -x "*.md" -x "log.txt" -x "package-lock.json" -x "package.json" -x "phpcs.xml" -x "*.DS_Store"
+# Remove vendor directory
+cd ..
+rm -rf vendor
+
+# Run composer to only install non-dev dependencies
+composer install --no-dev
+
+# Build ZIP file, excluding non-Plugin files
+rm convertkit-for-woocommerce.zip
+zip -r convertkit-for-woocommerce.zip . \
+-x "*.git*" \
+-x ".devcontainer/*" \
+-x ".scripts/*" \
+-x ".wordpress-org/*" \
+-x "log/*" \
+-x "tests/*" \
+-x "vendor/composer/*" \
+-x "vendor/convertkit/convertkit-wordpress-libraries/.github" \
+-x "vendor/convertkit/convertkit-wordpress-libraries/tests/*" \
+-x "vendor/convertkit/convertkit-wordpress-libraries/composer.json" \
+-x "vendor/autoload.php" \
+-x "*.distignore" \
+-x "*.env.*" \
+-x ".gitignore" \
+-x "*.md" \
+-x "*.yml" \
+-x "composer.json" \
+-x "composer.lock" \
+-x "*.xml" \
+-x "*.neon" \
+-x "*.dist" \
+-x "*.example" \
+-x "*.DS_Store" \
+
+# Run composer to install dev dependencies, returning enviornment back to original state
+composer update


### PR DESCRIPTION
## Summary

Improves the `build.sh` script for building a Plugin ZIP file locally, by including the Kit WordPress Libraries from the `vendor` folder, and excluding some other unnecessary assets.  This is occasionally used when troubleshooting specific creator sites and a specific build is needed for debugging an issue.  For published releases to wordpress.org, the [GitHub deploy action](https://github.com/Kit/convertkit-woocommerce/blob/fix-build-script/.github/workflows/deploy.yml) is still used.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)