### PR TITLE
Checkout Block: Cast `extensions` as array

### DIFF
--- a/includes/class-ckwc-checkout.php
+++ b/includes/class-ckwc-checkout.php
@@ -226,7 +226,7 @@ class CKWC_Checkout {
 
 		$this->save_opt_in_for_order(
 			$order,
-			(bool) ( array_key_exists( 'ckwc-opt-in', $request['extensions'] ) ? $request['extensions']['ckwc-opt-in']['ckwc_opt_in'] : false )
+			(bool) ( array_key_exists( 'ckwc-opt-in', (array) $request['extensions'] ) ? $request['extensions']['ckwc-opt-in']['ckwc_opt_in'] : false )
 		);
 
 	}

--- a/tests/EndToEnd/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
+++ b/tests/EndToEnd/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
@@ -107,7 +107,7 @@ class BackwardCompatSettingOptInCheckboxCest
 				'check_opt_in'             => true,
 				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
 				'subscription_event'       => 'processing',
-				'use_legacy_checkout'      => false,
+				'use_legacy_checkout'      => true,
 			]
 		);
 

--- a/tests/EndToEnd/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
+++ b/tests/EndToEnd/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
@@ -28,6 +28,9 @@ class BackwardCompatSettingOptInCheckboxCest
 
 		// Enable Integration and define its Access and Refresh Tokens.
 		$I->setupConvertKitPlugin($I);
+
+		// Setup Resources.
+		$I->setupConvertKitPluginResources($I);
 	}
 
 	/**
@@ -132,8 +135,6 @@ class BackwardCompatSettingOptInCheckboxCest
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
 		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
 	}
-
-
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.

--- a/tests/EndToEnd/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
+++ b/tests/EndToEnd/backward-compat/BackwardCompatSettingsOptInCheckboxCest.php
@@ -28,9 +28,6 @@ class BackwardCompatSettingOptInCheckboxCest
 
 		// Enable Integration and define its Access and Refresh Tokens.
 		$I->setupConvertKitPlugin($I);
-
-		// Load Settings screen.
-		$I->loadConvertKitSettingsScreen($I);
 	}
 
 	/**
@@ -43,6 +40,9 @@ class BackwardCompatSettingOptInCheckboxCest
 	 */
 	public function testOptInCheckboxBlockInEditor(EndToEndTester $I)
 	{
+		// Load Settings screen.
+		$I->loadConvertKitSettingsScreen($I);
+
 		// Enable the Opt-In Checkbox option.
 		$I->checkOption('#woocommerce_ckwc_display_opt_in');
 
@@ -85,6 +85,55 @@ class BackwardCompatSettingOptInCheckboxCest
 		// Confirm this displays the integration settings screen.
 		$I->seeCheckboxIsChecked('#woocommerce_ckwc_display_opt_in');
 	}
+
+	/**
+	 * Test that the Customer is subscribed to Kit when:
+	 * - The opt in checkbox is enabled in the integration Settings, and
+	 * - The opt in checkbox is checked on the WooCommerce checkout, and
+	 * - The Customer purchases a 'Simple' WooCommerce Product, and
+	 * - The Customer is subscribed at the point the WooCommerce Order is marked as processing.
+	 *
+	 * @since   1.9.6
+	 *
+	 * @param   EndToEndTester $I  Tester.
+	 */
+	public function testOptInWhenCheckedWithFormAndSimpleProduct(EndToEndTester $I)
+	{
+		// Create Product and Checkout for this test.
+		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig(
+			$I,
+			[
+				'display_opt_in'           => true,
+				'check_opt_in'             => true,
+				'plugin_form_tag_sequence' => 'form:' . $_ENV['CONVERTKIT_API_FORM_ID'],
+				'subscription_event'       => 'processing',
+				'use_legacy_checkout'      => false,
+			]
+		);
+
+		// Confirm that the email address was now added to ConvertKit.
+		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+
+		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
+		// in the integration's settings.
+		$I->apiCustomFieldDataIsEmpty($I, $subscriber);
+
+		// Check that the subscriber has the expected form and referrer value set.
+		$I->apiCheckSubscriberHasForm(
+			$I,
+			$subscriber['id'],
+			$_ENV['CONVERTKIT_API_FORM_ID'],
+			$_ENV['WORDPRESS_URL']
+		);
+
+		// Unsubscribe the email address, so we restore the account back to its previous state.
+		$I->apiUnsubscribe($subscriber['id']);
+
+		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
+		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+	}
+
+
 
 	/**
 	 * Deactivate and reset Plugin(s) after each test, if the test passes.


### PR DESCRIPTION
## Summary

Fixes [this reported issue](https://wordpress.org/support/topic/fatal-error-on-checkout-6/), where WooCommerce < 8.9.0 uses the `CKWC_Opt_In_Block_Integration` checkout block to render the opt in checkbox, resulting in an error when the `WP_REST_Request` `extensions` property isn't an array.

## Testing

- `BackwardCompatSettingOptInCheckboxCest:testOptInWhenCheckedWithFormAndSimpleProduct`: Tests that the opt-in checkbox works on checkout when using WooCommerce 8.4.0, with no fatal errors.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)