### PR TITLE
Tests: Use Named Arguments, Part 2

### DIFF
--- a/tests/EndToEnd/settings/SettingEnabledDisabledCest.php
+++ b/tests/EndToEnd/settings/SettingEnabledDisabledCest.php
@@ -42,7 +42,11 @@ class SettingEnabledDisabledCest
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
 
 		// Add Product to Cart and load Checkout.
-		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
+		$I->wooCommerceCheckoutWithProduct(
+			$I,
+			productID: $productID,
+			productName: 'Simple Product'
+		);
 
 		// Click Place order button.
 		$I->waitForElementNotVisible('.blockOverlay');

--- a/tests/EndToEnd/settings/SettingOptInCheckboxCest.php
+++ b/tests/EndToEnd/settings/SettingOptInCheckboxCest.php
@@ -173,7 +173,11 @@ class SettingOptInCheckboxCest
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
 
 		// Add Product to Cart and load Checkout.
-		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
+		$I->wooCommerceCheckoutWithProduct(
+			$I,
+			productID: $productID,
+			productName: 'Simple Product'
+		);
 
 		// Confirm that the Opt-In checkbox is displayed on the Checkout screen.
 		$I->seeElementInDOM('#ckwc_opt_in');
@@ -212,7 +216,11 @@ class SettingOptInCheckboxCest
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
 
 		// Add Product to Cart and load Checkout.
-		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
+		$I->wooCommerceCheckoutWithProduct(
+			$I,
+			productID: $productID,
+			productName: 'Simple Product'
+		);
 
 		// Confirm that the Opt-In checkbox is displayed on the Checkout screen.
 		$I->seeElementInDOM('#ckwc_opt_in');
@@ -251,7 +259,11 @@ class SettingOptInCheckboxCest
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
 
 		// Add Product to Cart and load Checkout.
-		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
+		$I->wooCommerceCheckoutWithProduct(
+			$I,
+			productID: $productID,
+			productName: 'Simple Product'
+		);
 
 		// Confirm that the Opt-In checkbox is displayed in the Billing section on the Checkout screen.
 		$I->seeElementInDOM('.woocommerce-billing-fields #ckwc_opt_in');
@@ -287,7 +299,11 @@ class SettingOptInCheckboxCest
 		$productID = $I->wooCommerceCreateSimpleProduct($I);
 
 		// Add Product to Cart and load Checkout.
-		$I->wooCommerceCheckoutWithProduct($I, $productID, 'Simple Product');
+		$I->wooCommerceCheckoutWithProduct(
+			$I,
+			productID: $productID,
+			productName: 'Simple Product'
+		);
 
 		// Confirm that the Opt-In checkbox is displayed in the Order section on the Checkout screen.
 		$I->seeElementInDOM('.woocommerce-additional-fields #ckwc_opt_in');

--- a/tests/EndToEnd/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
@@ -83,7 +83,7 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
 		);
 	}
 
@@ -118,7 +118,7 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteDoesNotExist(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed'
+			noteText: 'Customer subscribed'
 		);
 	}
 
@@ -170,7 +170,7 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
 		);
 	}
 
@@ -399,7 +399,7 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteDoesNotExist(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed'
+			noteText: 'Customer subscribed'
 		);
 	}
 
@@ -434,7 +434,7 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteDoesNotExist(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed'
+			noteText: 'Customer subscribed'
 		);
 	}
 
@@ -467,7 +467,7 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteDoesNotExist(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed'
+			noteText: 'Customer subscribed'
 		);
 	}
 
@@ -516,14 +516,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
 		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']'
 		);
 	}
 
@@ -572,14 +572,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
 		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']'
+			noteText: 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']'
 		);
 	}
 
@@ -628,14 +628,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
 		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']'
+			noteText: 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']'
 		);
 	}
 
@@ -684,14 +684,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
 		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']'
 		);
 	}
 
@@ -740,14 +740,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
 		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']'
+			noteText: 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']'
 		);
 	}
 
@@ -796,14 +796,14 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
 		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
 		$I->wooCommerceOrderNoteExists(
 			$I,
 			orderID: $result['order_id'],
-			note: 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']'
+			noteText: 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']'
 		);
 	}
 

--- a/tests/EndToEnd/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeCheckoutBlockOnOrderProcessingEventCest.php
@@ -58,7 +58,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -67,16 +71,20 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 	}
 
 	/**
@@ -107,7 +115,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+		$I->wooCommerceOrderNoteDoesNotExist(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed'
+		);
 	}
 
 	/**
@@ -133,14 +145,18 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
@@ -151,7 +167,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 	}
 
 	/**
@@ -182,14 +202,18 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
@@ -232,19 +256,27 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
-		$I->apiCustomFieldDataIsValid($I, $subscriber, $addressFields );
+		$I->apiCustomFieldDataIsValid(
+			$I,
+			subscriber: $subscriber,
+			addressFields: $addressFields
+		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
@@ -278,7 +310,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -315,7 +351,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -350,10 +390,17 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was still not added to ConvertKit.
-		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
+		$I->apiCheckSubscriberDoesNotExist(
+			$I,
+			emailAddress: $result['email_address']
+		);
 
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+		$I->wooCommerceOrderNoteDoesNotExist(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed'
+		);
 	}
 
 	/**
@@ -384,7 +431,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+		$I->wooCommerceOrderNoteDoesNotExist(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed'
+		);
 	}
 
 	/**
@@ -413,7 +464,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+		$I->wooCommerceOrderNoteDoesNotExist(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed'
+		);
 	}
 
 	/**
@@ -444,7 +499,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -454,10 +513,18 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']'
+		);
 	}
 
 	/**
@@ -488,7 +555,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -498,10 +569,18 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']'
+		);
 	}
 
 	/**
@@ -532,7 +611,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -542,10 +625,18 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']'
+		);
 	}
 
 	/**
@@ -576,7 +667,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -586,10 +681,18 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']'
+		);
 	}
 
 	/**
@@ -620,7 +723,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -630,10 +737,18 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']'
+		);
 	}
 
 	/**
@@ -664,7 +779,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -674,10 +793,18 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			note: 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']'
+		);
 	}
 
 	/**
@@ -709,7 +836,11 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -719,10 +850,18 @@ class SubscribeCheckoutBlockOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Change the Order's Status to any status other than 'Processing'.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'Pending payment');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'Pending payment'
+		);
 
 		// Change the Order's Status to 'Processing'.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'Processing');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'Processing'
+		);
 
 		// Confirm that the email address was not added to ConvertKit a second time.
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);

--- a/tests/EndToEnd/subscribe/SubscribeOnOrderCompletedEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeOnOrderCompletedEventCest.php
@@ -59,17 +59,25 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
@@ -103,7 +111,11 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was not added to ConvertKit.
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
@@ -134,17 +146,25 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
@@ -179,7 +199,11 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was still not added to ConvertKit.
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
@@ -212,7 +236,11 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was still not added to ConvertKit.
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
@@ -248,10 +276,18 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -295,14 +331,26 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
-		$I->apiCustomFieldDataIsValid($I, $subscriber, $addressFields );
+		$I->apiCustomFieldDataIsValid(
+			$I,
+			subscriber: $subscriber,
+			addressFields: $addressFields
+		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
@@ -338,10 +386,18 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -380,10 +436,18 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -417,7 +481,11 @@ class SubscribeOnOrderCompletedEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Change the Order status = Completed, to trigger the Order Completed event.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'wc-completed');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'wc-completed'
+		);
 
 		// Confirm that the email address was still not added to ConvertKit.
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);

--- a/tests/EndToEnd/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeOnOrderPendingPaymentEventCest.php
@@ -56,14 +56,18 @@ class SubscribeOnOrderPendingPaymentEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
@@ -119,14 +123,18 @@ class SubscribeOnOrderPendingPaymentEventCest
 		);
 
 		// Confirm that the email address was added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
@@ -160,14 +168,18 @@ class SubscribeOnOrderPendingPaymentEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
@@ -209,19 +221,27 @@ class SubscribeOnOrderPendingPaymentEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
-		$I->apiCustomFieldDataIsValid($I, $subscriber, $addressFields );
+		$I->apiCustomFieldDataIsValid(
+			$I,
+			subscriber: $subscriber,
+			addressFields: $addressFields
+		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
 		$I->apiUnsubscribe($subscriber['id']);
@@ -254,7 +274,11 @@ class SubscribeOnOrderPendingPaymentEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -290,7 +314,11 @@ class SubscribeOnOrderPendingPaymentEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);

--- a/tests/EndToEnd/subscribe/SubscribeOnOrderProcessingEventCest.php
+++ b/tests/EndToEnd/subscribe/SubscribeOnOrderProcessingEventCest.php
@@ -57,7 +57,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -66,9 +70,9 @@ class SubscribeOnOrderProcessingEventCest
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
@@ -130,7 +134,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -139,9 +147,9 @@ class SubscribeOnOrderProcessingEventCest
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
@@ -178,7 +186,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -186,9 +198,9 @@ class SubscribeOnOrderProcessingEventCest
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
@@ -227,18 +239,26 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct, and the name
 		// is not included in the address.
-		$I->apiCustomFieldDataIsValid($I, $subscriber, $addressFields );
+		$I->apiCustomFieldDataIsValid(
+			$I,
+			subscriber: $subscriber,
+			addressFields: $addressFields
+		);
 
 		// Check that the subscriber has the expected form and referrer value set.
 		$I->apiCheckSubscriberHasForm(
 			$I,
-			$subscriber['id'],
-			$_ENV['CONVERTKIT_API_FORM_ID'],
-			$_ENV['WORDPRESS_URL']
+			subscriberID: $subscriber['id'],
+			formID: $_ENV['CONVERTKIT_API_FORM_ID'],
+			referrer: $_ENV['WORDPRESS_URL']
 		);
 
 		// Unsubscribe the email address, so we restore the account back to its previous state.
@@ -272,7 +292,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -308,7 +332,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data exists and is correct.
 		$I->apiCustomFieldDataIsValid($I, $subscriber);
@@ -345,7 +373,11 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+		$I->wooCommerceOrderNoteDoesNotExist(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed'
+		);
 	}
 
 	/**
@@ -375,7 +407,11 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+		$I->wooCommerceOrderNoteDoesNotExist(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed'
+		);
 	}
 
 	/**
@@ -403,7 +439,11 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);
 
 		// Check that the Order's Notes does include a note from the Plugin confirming the Customer was subscribed.
-		$I->wooCommerceOrderNoteDoesNotExist($I, $result['order_id'], 'Customer subscribed');
+		$I->wooCommerceOrderNoteDoesNotExist(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed'
+		);
 	}
 
 	/**
@@ -433,7 +473,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -443,10 +487,18 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']'
+		);
 	}
 
 	/**
@@ -476,7 +528,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -486,10 +542,18 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']'
+		);
 	}
 
 	/**
@@ -519,7 +583,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -529,10 +597,18 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']'
+		);
 	}
 
 	/**
@@ -562,7 +638,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -572,10 +652,18 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Legacy Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_LEGACY_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_LEGACY_FORM_ID'] . ']'
+		);
 	}
 
 	/**
@@ -605,7 +693,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -615,10 +707,18 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Tag.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Tag: ' . $_ENV['CONVERTKIT_API_TAG_NAME'] . ' [' . $_ENV['CONVERTKIT_API_TAG_ID'] . ']'
+		);
 	}
 
 	/**
@@ -648,7 +748,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -658,10 +762,18 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Form.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Form: ' . $_ENV['CONVERTKIT_API_FORM_NAME'] . ' [' . $_ENV['CONVERTKIT_API_FORM_ID'] . ']'
+		);
 
 		// Check that the Order's Notes include a note from the Plugin confirming the Customer was subscribed to the Sequence.
-		$I->wooCommerceOrderNoteExists($I, $result['order_id'], 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']');
+		$I->wooCommerceOrderNoteExists(
+			$I,
+			orderID: $result['order_id'],
+			noteText: 'Customer subscribed to the Sequence: ' . $_ENV['CONVERTKIT_API_SEQUENCE_NAME'] . ' [' . $_ENV['CONVERTKIT_API_SEQUENCE_ID'] . ']'
+		);
 	}
 
 	/**
@@ -692,7 +804,11 @@ class SubscribeOnOrderProcessingEventCest
 		);
 
 		// Confirm that the email address was now added to ConvertKit.
-		$subscriber = $I->apiCheckSubscriberExists($I, $result['email_address'], 'First');
+		$subscriber = $I->apiCheckSubscriberExists(
+			$I,
+			emailAddress: $result['email_address'],
+			firstName: 'First'
+		);
 
 		// Confirm the subscriber's custom field data is empty, as no Order to Custom Field mapping was specified
 		// in the integration's settings.
@@ -702,10 +818,18 @@ class SubscribeOnOrderProcessingEventCest
 		$I->apiUnsubscribe($subscriber['id']);
 
 		// Change the Order's Status to any status other than 'Processing'.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'Pending payment');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'Pending payment'
+		);
 
 		// Change the Order's Status to 'Processing'.
-		$I->wooCommerceChangeOrderStatus($I, $result['order_id'], 'Processing');
+		$I->wooCommerceChangeOrderStatus(
+			$I,
+			orderID: $result['order_id'],
+			orderStatus: 'Processing'
+		);
 
 		// Confirm that the email address was not added to ConvertKit a second time.
 		$I->apiCheckSubscriberDoesNotExist($I, $result['email_address']);

--- a/tests/EndToEnd/sync-past-orders/SyncPastOrdersCLICest.php
+++ b/tests/EndToEnd/sync-past-orders/SyncPastOrdersCLICest.php
@@ -81,7 +81,12 @@ class SyncPastOrdersCLICest
 		$I->seeInShellOutput('WooCommerce Order ID #' . $orderID . ' added to Kit Purchase Data successfully. Kit Purchase ID: #');
 
 		// Confirm that the Order was added to ConvertKit.
-		$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+		$I->apiCheckPurchaseExists(
+			$I,
+			orderID: $result['order_id'],
+			emailAddress: $result['email_address'],
+			productID: $result['product_id']
+		);
 	}
 
 	/**
@@ -113,7 +118,12 @@ class SyncPastOrdersCLICest
 			$I->seeInShellOutput('WooCommerce Order ID #' . $orderID . ' added to Kit Purchase Data successfully. Kit Purchase ID: #');
 
 			// Confirm that the Order was added to ConvertKit.
-			$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+			$I->apiCheckPurchaseExists(
+				$I,
+				orderID: $result['order_id'],
+				emailAddress: $result['email_address'],
+				productID: $result['product_id']
+			);
 		}
 	}
 

--- a/tests/EndToEnd/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/EndToEnd/sync-past-orders/SyncPastOrdersCest.php
@@ -60,7 +60,12 @@ class SyncPastOrdersCest
 		$I->logOut();
 
 		// Add Product to Cart and load Checkout.
-		$I->wooCommerceCheckoutWithProduct($I, $productID, $productName, $emailAddress);
+		$I->wooCommerceCheckoutWithProduct(
+			$I,
+			productID: $productID,
+			productName: $productName,
+			emailAddress: $emailAddress
+		);
 
 		// Click Place order button.
 		$I->waitForElementNotVisible('.blockOverlay');
@@ -166,7 +171,11 @@ class SyncPastOrdersCest
 		$result = $I->wooCommerceCreateProductAndCheckoutWithConfig($I);
 
 		// Refund the Order.
-		$I->wooCommerceRefundOrder($I, $result['order_id'], 10);
+		$I->wooCommerceRefundOrder(
+			$I,
+			orderID: $result['order_id'],
+			amount: 10
+		);
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -213,7 +222,10 @@ class SyncPastOrdersCest
 		$I->seeElementInDOM('a#ckwc_sync_past_orders');
 
 		// Remove the email address from the Order.
-		$I->wooCommerceChangeOrderEmailAddress($I, $result['order_id'], '');
+		$I->wooCommerceChangeOrderEmailAddress(
+			$I,
+			orderID: $result['order_id']
+		);
 
 		// Load Settings screen.
 		$I->loadConvertKitSettingsScreen($I);
@@ -278,7 +290,12 @@ class SyncPastOrdersCest
 		$I->seeInSource('WooCommerce Order ID #' . $postID . ' added to Kit Purchase Data successfully.');
 
 		// Confirm that the purchase was added to ConvertKit.
-		$purchaseDataID = $I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+		$purchaseDataID = $I->apiCheckPurchaseExists(
+			$I,
+			orderID: $result['order_id'],
+			emailAddress: $result['email_address'],
+			productID: $result['product_id']
+		);
 
 		// Confirm that the Cancel Sync button is disabled.
 		$I->seeElementInDOM('a.cancel[disabled]');
@@ -290,8 +307,18 @@ class SyncPastOrdersCest
 		$I->seeInSource('Enable Kit integration');
 
 		// Confirm that the Transaction ID is stored in the Order's metadata.
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_sent', 'yes');
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_id', $purchaseDataID);
+		$I->wooCommerceOrderMetaKeyAndValueExist(
+			$I,
+			orderID: $result['order_id'],
+			metaKey: 'ckwc_purchase_data_sent',
+			metaValue: 'yes'
+		);
+		$I->wooCommerceOrderMetaKeyAndValueExist(
+			$I,
+			orderID: $result['order_id'],
+			metaKey: 'ckwc_purchase_data_id',
+			metaValue: $purchaseDataID
+		);
 	}
 
 	/**
@@ -334,7 +361,11 @@ class SyncPastOrdersCest
 
 		// Remove the Transaction ID metadata in the Order, as if it were sent
 		// by 1.4.2 or older.
-		$I->wooCommerceOrderDeleteMeta($I, $postID, 'ckwc_purchase_data_id');
+		$I->wooCommerceOrderDeleteMeta(
+			$I,
+			orderID: $result['order_id'],
+			metaKey: 'ckwc_purchase_data_id'
+		);
 
 		// Login as the Administrator, if we're not already logged in.
 		if ( ! $I->amLoggedInAsAdmin($I) ) {
@@ -360,14 +391,29 @@ class SyncPastOrdersCest
 		$I->seeInSource('WooCommerce Order ID #' . $postID . ' added to Kit Purchase Data successfully.');
 
 		// Confirm that the purchase was added to ConvertKit.
-		$purchaseDataID = $I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+		$purchaseDataID = $I->apiCheckPurchaseExists(
+			$I,
+			orderID: $result['order_id'],
+			emailAddress: $result['email_address'],
+			productID: $result['product_id']
+		);
 
 		// Confirm that the Cancel Sync button is disabled.
 		$I->seeElementInDOM('a.cancel[disabled]');
 
 		// Confirm that the Transaction ID is stored in the Order's metadata.
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_sent', 'yes');
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_id', $purchaseDataID);
+		$I->wooCommerceOrderMetaKeyAndValueExist(
+			$I,
+			orderID: $result['order_id'],
+			metaKey: 'ckwc_purchase_data_sent',
+			metaValue: 'yes'
+		);
+		$I->wooCommerceOrderMetaKeyAndValueExist(
+			$I,
+			orderID: $result['order_id'],
+			metaKey: 'ckwc_purchase_data_id',
+			metaValue: $purchaseDataID
+		);
 	}
 
 	/**
@@ -418,7 +464,11 @@ class SyncPastOrdersCest
 		$I->dontSeeElementInDOM('button.woocommerce-save-button');
 
 		// Confirm that the purchase was not added to ConvertKit.
-		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address'], $result['product_id']);
+		$I->apiCheckPurchaseDoesNotExist(
+			$I,
+			orderID: $result['order_id'],
+			emailAddress: $result['email_address']
+		);
 	}
 
 	/**

--- a/tests/EndToEnd/sync-past-orders/SyncPastOrdersCest.php
+++ b/tests/EndToEnd/sync-past-orders/SyncPastOrdersCest.php
@@ -363,7 +363,7 @@ class SyncPastOrdersCest
 		// by 1.4.2 or older.
 		$I->wooCommerceOrderDeleteMeta(
 			$I,
-			orderID: $result['order_id'],
+			orderID: $postID,
 			metaKey: 'ckwc_purchase_data_id'
 		);
 

--- a/tests/EndToEnd/sync-past-orders/SyncPastOrdersHPOSCLICest.php
+++ b/tests/EndToEnd/sync-past-orders/SyncPastOrdersHPOSCLICest.php
@@ -82,7 +82,12 @@ class SyncPastOrdersHPOSCLICest
 		$I->seeInShellOutput('WooCommerce Order ID #' . $orderID . ' added to Kit Purchase Data successfully. Kit Purchase ID: #');
 
 		// Confirm that the Order was added to ConvertKit.
-		$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+		$I->apiCheckPurchaseExists(
+			$I,
+			orderID: $result['order_id'],
+			emailAddress: $result['email_address'],
+			productID: $result['product_id']
+		);
 	}
 
 	/**
@@ -114,7 +119,12 @@ class SyncPastOrdersHPOSCLICest
 			$I->seeInShellOutput('WooCommerce Order ID #' . $orderID . ' added to Kit Purchase Data successfully. Kit Purchase ID: #');
 
 			// Confirm that the Order was added to ConvertKit.
-			$I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+			$I->apiCheckPurchaseExists(
+				$I,
+				orderID: $result['order_id'],
+				emailAddress: $result['email_address'],
+				productID: $result['product_id']
+			);
 		}
 	}
 

--- a/tests/EndToEnd/sync-past-orders/SyncPastOrdersHPOSCest.php
+++ b/tests/EndToEnd/sync-past-orders/SyncPastOrdersHPOSCest.php
@@ -357,7 +357,12 @@ class SyncPastOrdersHPOSCest
 
 		// Remove the Transaction ID metadata in the Order, as if it were sent
 		// by 1.4.2 or older.
-		$I->wooCommerceOrderDeleteMeta($I, $postID, 'ckwc_purchase_data_id', true);
+		$I->wooCommerceOrderDeleteMeta(
+			$I,
+			orderID: $postID,
+			metaKey: 'ckwc_purchase_data_id',
+			hposEnabled: true
+		);
 
 		// Login as the Administrator, if we're not already logged in.
 		if ( ! $I->amLoggedInAsAdmin($I) ) {

--- a/tests/EndToEnd/sync-past-orders/SyncPastOrdersHPOSCest.php
+++ b/tests/EndToEnd/sync-past-orders/SyncPastOrdersHPOSCest.php
@@ -61,7 +61,12 @@ class SyncPastOrdersHPOSCest
 		$I->logOut();
 
 		// Add Product to Cart and load Checkout.
-		$I->wooCommerceCheckoutWithProduct($I, $productID, $productName, $emailAddress);
+		$I->wooCommerceCheckoutWithProduct(
+			$I,
+			productID: $productID,
+			productName: $productName,
+			emailAddress: $emailAddress
+		);
 
 		// Click Place order button.
 		$I->waitForElementNotVisible('.blockOverlay');
@@ -279,7 +284,12 @@ class SyncPastOrdersHPOSCest
 		$I->seeInSource('WooCommerce Order ID #' . $postID . ' added to Kit Purchase Data successfully.');
 
 		// Confirm that the purchase was added to ConvertKit.
-		$purchaseDataID = $I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+		$purchaseDataID = $I->apiCheckPurchaseExists(
+			$I,
+			orderID: $result['order_id'],
+			emailAddress: $result['email_address'],
+			productID: $result['product_id']
+		);
 
 		// Confirm that the Cancel Sync button is disabled.
 		$I->seeElementInDOM('a.cancel[disabled]');
@@ -291,8 +301,20 @@ class SyncPastOrdersHPOSCest
 		$I->seeInSource('Enable Kit integration');
 
 		// Confirm that the Transaction ID is stored in the Order's metadata.
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_sent', 'yes', true);
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_id', $purchaseDataID, true);
+		$I->wooCommerceOrderMetaKeyAndValueExist(
+			$I,
+			orderID: $result['order_id'],
+			metaKey: 'ckwc_purchase_data_sent',
+			metaValue: 'yes',
+			hposEnabled: true
+		);
+		$I->wooCommerceOrderMetaKeyAndValueExist(
+			$I,
+			orderID: $result['order_id'],
+			metaKey: 'ckwc_purchase_data_id',
+			metaValue: $purchaseDataID,
+			hposEnabled: true
+		);
 	}
 
 	/**
@@ -361,14 +383,31 @@ class SyncPastOrdersHPOSCest
 		$I->seeInSource('WooCommerce Order ID #' . $postID . ' added to Kit Purchase Data successfully.');
 
 		// Confirm that the purchase was added to ConvertKit.
-		$purchaseDataID = $I->apiCheckPurchaseExists($I, $result['order_id'], $result['email_address'], $result['product_id']);
+		$purchaseDataID = $I->apiCheckPurchaseExists(
+			$I,
+			orderID: $result['order_id'],
+			emailAddress: $result['email_address'],
+			productID: $result['product_id']
+		);
 
 		// Confirm that the Cancel Sync button is disabled.
 		$I->seeElementInDOM('a.cancel[disabled]');
 
 		// Confirm that the Transaction ID is stored in the Order's metadata.
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_sent', 'yes', true);
-		$I->wooCommerceOrderMetaKeyAndValueExist($I, $postID, 'ckwc_purchase_data_id', $purchaseDataID, true);
+		$I->wooCommerceOrderMetaKeyAndValueExist(
+			$I,
+			orderID: $result['order_id'],
+			metaKey: 'ckwc_purchase_data_sent',
+			metaValue: 'yes',
+			hposEnabled: true
+		);
+		$I->wooCommerceOrderMetaKeyAndValueExist(
+			$I,
+			orderID: $result['order_id'],
+			metaKey: 'ckwc_purchase_data_id',
+			metaValue: $purchaseDataID,
+			hposEnabled: true
+		);
 	}
 
 	/**
@@ -419,7 +458,11 @@ class SyncPastOrdersHPOSCest
 		$I->dontSeeElementInDOM('button.woocommerce-save-button');
 
 		// Confirm that the purchase was not added to ConvertKit.
-		$I->apiCheckPurchaseDoesNotExist($I, $result['order_id'], $result['email_address'], $result['product_id']);
+		$I->apiCheckPurchaseDoesNotExist(
+			$I,
+			orderID: $result['order_id'],
+			emailAddress: $result['email_address']
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds named arguments to the remaining tests, following https://github.com/Kit/convertkit-woocommerce/pull/228

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](https://github.com/ConvertKit/convertkit-wordpress/blob/main/TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](https://github.com/ConvertKit/convertkit-wordpress/blob/main/DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)