### PR TITLE
Composer: Add Commands

### DIFF
--- a/.scripts/create-plugin-zip.sh
+++ b/.scripts/create-plugin-zip.sh
@@ -1,9 +1,3 @@
-# Build ACTIONS-FILTERS.md
-php create-actions-filters-docs.php
-
-# Generate .pot file
-php -n $(which wp) i18n make-pot ../ ../languages/woocommerce-convertkit.pot
-
 # Remove vendor directory
 cd ..
 rm -rf vendor

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,29 @@
         "wp-coding-standards/wpcs": "^3.0.0",
         "phpstan/phpstan": "^1.0 || ^2.0",
         "szepeviktor/phpstan-wordpress": "^1.0 || ^2.0",
-        "wp-cli/wp-cli": "^2.11",
         "lucatume/wp-browser": "^3.0 || ^4.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "scripts": {
+        "create-release-assets": [
+            "php -n $(which wp) i18n make-pot . languages/woocommerce-convertkit.pot",
+            "@php .scripts/create-actions-filters-docs.php"
+        ],
+        "create-pot": "php -n $(which wp) i18n make-pot . languages/woocommerce-convertkit.pot",
+        "create-dev-docs": "@php .scripts/create-actions-filters-docs.php",
+        "phpcs": "vendor/bin/phpcs ./ -s -v",
+        "phpcs-tests": "vendor/bin/phpcs ./tests --standard=phpcs.tests.xml -s -v",
+        "phpstan": "vendor/bin/phpstan analyse --memory-limit=1250M",
+        "test": [
+            "vendor/bin/codecept build @no_additional_args",
+            "vendor/bin/codecept run EndToEnd @additional_args --fail-fast"
+        ],
+        "test-integration": [
+            "vendor/bin/codecept build @no_additional_args",
+            "vendor/bin/codecept run Integration @additional_args --fail-fast"
+        ]
+    },
     "archive": {
         "exclude": [
             "!vendor/*",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "wp-coding-standards/wpcs": "^3.0.0",
         "phpstan/phpstan": "^1.0 || ^2.0",
         "szepeviktor/phpstan-wordpress": "^1.0 || ^2.0",
-        "lucatume/wp-browser": "^3.0 || ^4.0"
+        "lucatume/wp-browser": "^3.0 || ^4.0",
+        "wp-cli/wp-cli": "^2.12"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
## Summary

Registers a number of commands in the `scripts` section of Composer, which serve as shorthand commands for testing and other common tasks performed in development, to save repetitively typing longer commands with commonly used flags / arguments.

| Command | Description |
|---------|-------------|
| `create-release-assets` | Generates both the language translation template file (POT) and documentation for actions/filters |
| `create-pot` | Generates just the language translation template file (POT) |
| `create-dev-docs` | Generates just the documentation for actions/filters |
| `phpcs` | Runs PHP CodeSniffer on the entire plugin codebase |
| `phpcs-tests` | Runs PHP CodeSniffer specifically on the tests directory using test-specific standards |
| `phpstan` | Runs PHPStan static analysis with increased memory limit |
| `test` | Builds and runs end-to-end tests with fail-fast enabled |
| `test-integration` | Builds and runs integration tests with fail-fast enabled |

Commands can be run using e.g. `composer test` or `composer phpstan`

<img width="852" alt="Screenshot 2025-06-19 at 20 07 30" src="https://github.com/user-attachments/assets/904b1455-a2dd-472a-a7a4-b773383a5ca2" />

## Testing

Existing tests pass

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)