### PR TITLE
Tests: Fix Plugin Deactivation in wp-browser 4.5.6+

### DIFF
--- a/tests/Support/Helper/ThirdPartyPlugin.php
+++ b/tests/Support/Helper/ThirdPartyPlugin.php
@@ -42,7 +42,9 @@ class ThirdPartyPlugin extends \Codeception\Module
 
 			default:
 				// Activate the Plugin.
-				$I->activatePlugin($name);
+				$I->checkOption('//*[@data-slug="' . $name . '"]/th/input');
+				$I->selectOption('action', 'activate-selected');
+				$I->click('#doaction');
 				break;
 		}
 
@@ -86,7 +88,9 @@ class ThirdPartyPlugin extends \Codeception\Module
 
 			default:
 				// Deactivate the Plugin.
-				$I->deactivatePlugin($name);
+				$I->checkOption('//*[@data-slug="' . $name . '"]/th/input');
+				$I->selectOption('action', 'deactivate-selected');
+				$I->click('#doaction');
 				break;
 		}
 	}


### PR DESCRIPTION
## Summary

In [wp-browser 4.5.6](https://github.com/lucatume/wp-browser/releases/tag/4.5.6), the selector used to activate or deactivate a plugin was updated - moving from the  bulk action checkboxes on the Plugins screen to the individual Activate/Deactivate links.

As a result, this plugin’s tests fail because they attempt to deactivate plugins without first checking if they are active. When a plugin is inactive, the Deactivate link is not available, which leads to test failures.

<img width="1080" height="194" alt="Screenshot 2025-09-09 at 12 48 49" src="https://github.com/user-attachments/assets/70709163-92e5-4c36-88c4-02c5311c1c6f" />

This PR resolves by using the bulk actions to activate/deactivate Plugins, as wp-browser did in < 4.5.6. Using the deactivation link isn't guaranteed to work, because many Plugins hijack this with their own UI to survey the user on why they're deactivating a Plugin vs. just honoring the request.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)