### PR TITLE
Improve Refresh Resource Button

### DIFF
--- a/admin/class-ckwc-admin-bulk-edit.php
+++ b/admin/class-ckwc-admin-bulk-edit.php
@@ -56,6 +56,7 @@ class CKWC_Admin_Bulk_Edit {
 
 		// Enqueue CSS.
 		wp_enqueue_style( 'ckwc-bulk-quick-edit', CKWC_PLUGIN_URL . 'resources/backend/css/bulk-quick-edit.css', array(), CKWC_PLUGIN_VERSION );
+		wp_enqueue_style( 'ckwc-refresh-resources', CKWC_PLUGIN_URL . 'resources/backend/css/refresh-resources.css', array(), CKWC_PLUGIN_VERSION );
 
 		// Output Bulk Edit fields in the footer of the Administration screen.
 		add_action( 'in_admin_footer', array( $this, 'bulk_edit_fields' ), 10 );

--- a/admin/class-ckwc-admin-post-type.php
+++ b/admin/class-ckwc-admin-post-type.php
@@ -87,6 +87,9 @@ class CKWC_Admin_Post_Type {
 		// Enqueue Select2 CSS.
 		ckwc_select2_enqueue_styles();
 
+		// Enqueue Refresh Resources CSS.
+		wp_enqueue_style( 'ckwc-refresh-resources', CKWC_PLUGIN_URL . 'resources/backend/css/refresh-resources.css', array(), CKWC_PLUGIN_VERSION );
+
 	}
 
 	/**

--- a/resources/backend/css/refresh-resources.css
+++ b/resources/backend/css/refresh-resources.css
@@ -2,14 +2,18 @@
 	width: 36px;
 	height: 32px;
 }
+
 @keyframes kit-spin-refresh-resources-button {
+
 	from {
 		transform: rotate(0deg);
 	}
+
 	to {
 		transform: rotate(360deg);
 	}
 }
+
 .ckwc-refresh-resources.is-refreshing .dashicons {
 	animation: kit-spin-refresh-resources-button 1s linear infinite;
 }

--- a/resources/backend/css/refresh-resources.css
+++ b/resources/backend/css/refresh-resources.css
@@ -10,6 +10,6 @@
 		transform: rotate(360deg);
 	}
 }
-.ckwc-refresh-resources:disabled .dashicons {
+.ckwc-refresh-resources.is-refreshing .dashicons {
 	animation: kit-spin-refresh-resources-button 1s linear infinite;
 }

--- a/resources/backend/css/refresh-resources.css
+++ b/resources/backend/css/refresh-resources.css
@@ -1,0 +1,15 @@
+.ckwc-refresh-resources {
+	width: 36px;
+	height: 32px;
+}
+@keyframes kit-spin-refresh-resources-button {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+.ckwc-refresh-resources:disabled .dashicons {
+	animation: kit-spin-refresh-resources-button 1s linear infinite;
+}

--- a/resources/backend/css/select2.css
+++ b/resources/backend/css/select2.css
@@ -26,12 +26,6 @@
 	margin: 0;
 }
 
-/* Set size of refresh button */
-.ckwc-select2-container button.ckwc-refresh-resources {
-	width: 36px;
-	height: 32px;
-}
-
 /* Align select and refresh button onto a single row */
 .ckwc-select2-container-grid {
 	display: grid;

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -42,7 +42,9 @@ jQuery(document).ready(function ($) {
 					ckwcRefreshResourcesOutputErrorNotice(response.data);
 
 					// Enable button.
-					$(button).prop('disabled', false).removeClass('is-refreshing');
+					$(button)
+						.prop('disabled', false)
+						.removeClass('is-refreshing');
 
 					return;
 				}

--- a/resources/backend/js/refresh-resources.js
+++ b/resources/backend/js/refresh-resources.js
@@ -25,7 +25,7 @@ jQuery( document ).ready(
 				field      = $( button ).data( 'field' );
 
 				// Disable button.
-				$( button ).prop( 'disabled', true );
+				$( button ).prop( 'disabled', true ).addClass( 'is-refreshing' );
 
 				// Perform AJAX request to refresh resource.
 				$.ajax(
@@ -51,7 +51,7 @@ jQuery( document ).ready(
 								ckwcRefreshResourcesOutputErrorNotice( response.data );
 
 								// Enable button.
-								$( button ).prop( 'disabled', false );
+								$( button ).prop( 'disabled', false ).removeClass( 'is-refreshing' );
 
 								return;
 							}
@@ -97,7 +97,7 @@ jQuery( document ).ready(
 							$( '.ckwc-select2' ).select2();
 
 							// Enable button.
-							$( button ).prop( 'disabled', false );
+							$( button ).prop( 'disabled', false ).removeClass( 'is-refreshing' );
 
 						}
 					}
@@ -114,7 +114,7 @@ jQuery( document ).ready(
 						ckwcRefreshResourcesOutputErrorNotice( 'Kit for WooCommerce: ' + response.status + ' ' + response.statusText );
 
 						// Enable button.
-						$( button ).prop( 'disabled', false );
+						$( button ).prop( 'disabled', false ).removeClass( 'is-refreshing' );
 					}
 				);
 


### PR DESCRIPTION
## Summary

Improves the refresh resources buttons, by rotating the refresh icon until the update completes. Also moves CSS to its own stylesheet, as we use this across:
- product settings,
- quick/bulk edit

![Area](https://github.com/user-attachments/assets/0b9246e7-7573-4c1c-9706-3ecaff17ed37)

Previously, the button would change its state to disabled, with no on screen indication of what was happening until the button re-enabled when the update completed.

## Testing

Existing tests pass.

## Checklist

* [x] I have [written a test](TESTING.md#writing-an-end-to-end-test) and included it in this PR
* [x] I have [run all tests](TESTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](TESTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](DEVELOPMENT.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](DEVELOPMENT.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)